### PR TITLE
chore: clean up types and fix linting errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "mycommand"
+  ]
+}

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { prepareRows, scanForEol } from '../../service/eol/eol.svc'
 import { promptComponentDetails } from '../../service/eol/eol.ui'
+import { ScanResult } from '../../service/nes/modules/sbom'
 
 export default class ScanEol extends Command {
   static override args = {
@@ -24,7 +25,7 @@ export default class ScanEol extends Command {
   }
 
 
-  public async run(): Promise<any> {
+  public async run(): Promise<ScanResult | { components: [] }> {
     const { flags } = await this.parse(ScanEol)
 
     const dir = path.resolve(flags.dir)

--- a/src/service/eol/eol.types.ts
+++ b/src/service/eol/eol.types.ts
@@ -11,6 +11,9 @@ export interface ScanOptions {
   cdxgen?: CdxGenOptions
 }
 export interface CdxCreator {
-  // eslint-disable-next-line no-unused-vars
   (dir: string, opts: CdxGenOptions): Promise<{ bomJson: Sbom }>
+}
+
+export interface SbomScan<T> {
+  <SB>(sbom: SB): Promise<T>
 }

--- a/src/service/eol/eol.ui.ts
+++ b/src/service/eol/eol.ui.ts
@@ -2,12 +2,16 @@
 import { ux } from '@oclif/core'
 import inquirer from 'inquirer'
 
+import { ScanResultComponent } from '../nes/modules/sbom';
 
 interface Line {
   daysEol?: number
-  purl: string
-  info?: any
-  status: string
+  purl: ScanResultComponent['purl']
+  info?: {
+    eolAt?: Date,
+    isEol: boolean
+  }
+  status: ScanResultComponent['status']
 }
 
 function daysBetween(date1: Date, date2: Date) {
@@ -68,7 +72,6 @@ export function promptComponentDetails(lines: Line[]) {
   const context = {
     longest: lines
       .map(l => l.purl.length)
-      // eslint-disable-next-line unicorn/no-array-reduce
       .reduce((a, l) => Math.max(a, l), 0),
     total: lines.length
   }

--- a/src/service/nes/modules/sbom.test.ts
+++ b/src/service/nes/modules/sbom.test.ts
@@ -27,7 +27,7 @@ describe('SBOM Scanner', () => {
     expect(result).has.property('components')
 
     // make sure the scan has the components from above
-    for (const key of mock.components.map(c => c.purl)) {
+    for (const key of Object.keys(mock.components)) {
       expect(result.components).to.have.property(key)
     }
   });
@@ -54,10 +54,10 @@ const mocked = {
     insights: {
       scan: {
         eol: {
-          components: [
-            { info: STATUS_OK, purl: 'pkg:npm/camelcase@6.3.0', 'status': 'OK' },
-            { info: STATUS_EOL(), purl: 'pkg:npm/bootstrap@3.3.0', 'status': 'EOL' }
-          ],
+          components: {
+            'pkg:npm/bootstrap@3.3.0': { info: STATUS_EOL(), purl: 'pkg:npm/bootstrap@3.3.0', 'status': 'EOL' },
+            'pkg:npm/camelcase@6.3.0': { info: STATUS_OK, purl: 'pkg:npm/camelcase@6.3.0', 'status': 'OK' }
+          },
           diagnostics: {
             __mock: true
           },

--- a/src/service/nes/modules/sbom.ts
+++ b/src/service/nes/modules/sbom.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client/core"
 
 import { log } from '../../../utils/log.util';
+import { SbomMap } from '../../eol/eol.types';
 import { ApolloHelper } from "../nes.client"
-
 
 export const buildScanResult =
   (scan: ScanResponseReport): ScanResult => ({
@@ -12,7 +12,7 @@ export const buildScanResult =
   })
 
 export const SbomScanner = (client: ApolloHelper) =>
-  async (sbom: any): Promise<ScanResult> => {
+  async (sbom: SbomMap ): Promise<ScanResult> => {
 
     const input: ScanInput = { components: sbom.purls, type: 'SBOM' }
     const res = await client.mutate<ScanResponse, { input: ScanInput }>(M_SCAN.gql, { input })

--- a/src/service/nes/nes.client.ts
+++ b/src/service/nes/nes.client.ts
@@ -10,25 +10,19 @@ import {
 import 'isomorphic-fetch';
 import { default as fetch } from 'node-fetch'
 
-import { SbomScanner as sbomScanner, ScanResult } from './modules/sbom';
-
+import { SbomMap } from '../eol/eol.types';
+import { SbomScanner as sbomScanner, ScanResult } from '../nes/modules/sbom';
 
 type Fetch = typeof fetch
 type Params = Parameters<Fetch>
-
 
 export const fetcher = {
   fetch: ((...args: Params) => fetch(...args)) as Fetch
 }
 
-
-interface SbomScan {
-  <SB>(sbom: SB): Promise<ScanResult>
-}
-
 export interface NesClient {
   scan: {
-    sbom: SbomScan
+    sbom: (sbom: SbomMap) => Promise<ScanResult>
   }
 }
 

--- a/src/service/nes/types.ts
+++ b/src/service/nes/types.ts
@@ -1,10 +1,10 @@
 export type JSONValue =
-  | string
-  | number
   | boolean
+  | JSONValue[]
   | null
-  | { [key: string]: JSONValue }
-  | JSONValue[];
+  | number
+  | string
+  | { [key: string]: JSONValue };
 
 export type Options = {
   consent: boolean;

--- a/test/hooks/prerun/CommandContextHook.test.ts
+++ b/test/hooks/prerun/CommandContextHook.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/filename-case */
 import {runHook} from '@oclif/test'
 import {expect} from 'chai'
 

--- a/types/cdxgen.d.ts
+++ b/types/cdxgen.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "@cyclonedx/cdxgen" {
   /**
    * For all modules in the specified package, creates a list of
@@ -60,6 +61,7 @@ declare module "@cyclonedx/cdxgen" {
   export function mergeDependencies(
     dependencies: any,
     newDependencies: any,
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     parentComponent?: {}
   ): ({ dependsOn: any[]; provides: any[]; ref: string; } | { dependsOn: any[]; provides?: undefined; ref: string; })[];
 


### PR DESCRIPTION
- Fix `NesClient.scan.sbom` type
- Remove `any` where feasible.
- Add explicit return types where feasible
- Connect `Line` type with `ScanResultComponent` type