### PR TITLE
chore: add warning for unknown purls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "cSpell.words": ["mycommand", "prerun"],
+  "cSpell.words": ["mycommand", "prerun", "XEOL"],
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/service/eol/eol.types.ts
+++ b/src/service/eol/eol.types.ts
@@ -24,5 +24,3 @@ export interface ScanOptions {
   cdxgen?: CdxGenOptions;
 }
 export type CdxCreator = (dir: string, opts: CdxGenOptions) => Promise<{ bomJson: Sbom }>;
-
-export type SbomScan<T> = <SB>(sbom: SB) => Promise<T>;

--- a/src/service/line.ts
+++ b/src/service/line.ts
@@ -1,14 +1,14 @@
 import { ux } from '@oclif/core';
-import type { ScanResultComponent } from './nes/modules/sbom.ts';
+import type { ScanResultComponent, ComponentStatus } from './nes/modules/sbom.ts';
 
 export interface Line {
-  daysEol?: number;
+  daysEol: number | undefined;
   purl: ScanResultComponent['purl'];
-  info?: {
-    eolAt?: Date;
+  info: {
+    eolAt: Date | null;
     isEol: boolean;
   };
-  status: ScanResultComponent['status'];
+  status: ComponentStatus;
 }
 
 export function daysBetween(date1: Date, date2: Date) {
@@ -16,7 +16,7 @@ export function daysBetween(date1: Date, date2: Date) {
   return Math.round((date2.getTime() - date1.getTime()) / msPerDay);
 }
 
-export function getMessageAndStatus(status: string, eolAt?: Date) {
+export function getMessageAndStatus(status: string, eolAt: Date | null) {
   let msg = '';
   let stat = '';
 
@@ -48,8 +48,6 @@ export function getMessageAndStatus(status: string, eolAt?: Date) {
 
 export function formatLine(l: Line, idx: number, ctx: { longest: number; total: number }) {
   let { info, purl, status } = l;
-
-  info = info || { eolAt: new Date(), isEol: false };
 
   if (info.isEol && status !== 'EOL') {
     throw new Error(`isEol is true but status is not EOL: ${purl}`);

--- a/src/service/nes/modules/sbom.test.ts
+++ b/src/service/nes/modules/sbom.test.ts
@@ -1,7 +1,8 @@
 import { ok } from 'node:assert';
+import { describe, it } from 'node:test';
 
-import type { ApolloHelper } from '../nes.client';
-import { type ScanResult, SbomScanner as sbomScanner } from './sbom';
+import type { ApolloHelper } from '../nes.client.ts';
+import { type ScanResult, type ScanResultComponent, SbomScanner as sbomScanner } from './sbom.ts';
 
 describe('SBOM Scanner', () => {
   it('parses response and creates components record', async () => {
@@ -29,7 +30,7 @@ describe('SBOM Scanner', () => {
   });
 });
 
-const STATUS_OK = { isEol: false, isUnsafe: false };
+const STATUS_OK = { eolAt: null, isEol: false, isUnsafe: false };
 
 const DATE_MS = 1000 * 60 * 60 * 24;
 const STATUS_EOL = () => ({
@@ -38,29 +39,29 @@ const STATUS_EOL = () => ({
   isUnsafe: false,
 });
 
+const components = new Map<string, ScanResultComponent>();
+components.set('pkg:npm/bootstrap@3.3.0', {
+  info: STATUS_EOL(),
+  purl: 'pkg:npm/bootstrap@3.3.0',
+  status: 'EOL',
+})
+components.set('pkg:npm/camelcase@6.3.0', {
+  info: STATUS_OK,
+  purl: 'pkg:npm/camelcase@6.3.0',
+  status: 'OK',
+})
 const mocked = {
   success: {
     insights: {
       scan: {
         eol: {
-          components: {
-            'pkg:npm/bootstrap@3.3.0': {
-              info: STATUS_EOL(),
-              purl: 'pkg:npm/bootstrap@3.3.0',
-              status: 'EOL',
-            },
-            'pkg:npm/camelcase@6.3.0': {
-              info: STATUS_OK,
-              purl: 'pkg:npm/camelcase@6.3.0',
-              status: 'OK',
-            },
-          },
+          components,
           diagnostics: {
             __mock: true,
           },
           message: 'Your scan was completed successfully!',
           success: true,
-        } as ScanResult,
+        } satisfies ScanResult,
       },
     },
   },

--- a/src/service/nes/modules/sbom.ts
+++ b/src/service/nes/modules/sbom.ts
@@ -4,11 +4,17 @@ import { log } from '../../../utils/log.util.ts';
 import type { SbomMap } from '../../eol/eol.types.ts';
 import type { ApolloHelper } from '../nes.client.ts';
 
-export const buildScanResult = (scan: ScanResponseReport): ScanResult => ({
-  components: Object.fromEntries(scan.components.map((c) => [c.purl, c])),
-  message: scan.message,
-  success: true,
-});
+export const buildScanResult = (scan: ScanResponseReport): ScanResult => {
+  const components = new Map<string, ScanResultComponent>()
+  for (const c of scan.components) {
+    components.set(c.purl, c)
+  }
+  return {
+    components,
+    message: scan.message,
+    success: true,
+  }
+};
 
 export const SbomScanner =
   (client: ApolloHelper) =>
@@ -25,11 +31,7 @@ export const SbomScanner =
     }
 
     const result = buildScanResult(scan);
-    // const result: ScanResult = {
-    //   components: Object.fromEntries(scan.components.map((c) => [c.purl, c])),
-    //   message: scan.message,
-    //   success: true
-    // }
+
     return result;
   };
 
@@ -50,19 +52,22 @@ export interface ScanResponseReport {
   success: boolean;
 }
 export interface ScanResult {
-  components: Record<string, ScanResultComponent>;
+  components: Map<string, ScanResultComponent>;
   diagnostics?: Record<string, unknown>;
   message: string;
   success: boolean;
 }
+
+export type ComponentStatus = 'EOL' | 'LTS' | 'OK'
+
 export interface ScanResultComponent {
-  info?: {
-    eolAt?: Date;
+  info: {
+    eolAt: Date | null;
     isEol: boolean;
     isUnsafe: boolean;
   };
   purl: string;
-  status: 'EOL' | 'LTS' | 'OK';
+  status?: ComponentStatus;
 }
 
 const M_SCAN = {

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,4 +1,0 @@
-export function daysBetween(date1: Date, date2: Date) {
-  const msPerDay = 1000 * 60 * 60 * 24 + 15; // milliseconds in a day plus 15 ms
-  return Math.round((date2.getTime() - date1.getTime()) / msPerDay);
-}


### PR DESCRIPTION
This commit adds a warning in cases where a generated sbom has a purl, but the NES/XEOL database does not have any information.

We may want to fail silently instead. But even if we don't want the CLI to report anything to the user, it may be worth it to eventually track EOL 'misses' in some form.

This commit also improves typing in several ways that makes it easier to trace why scan details might be missing in the first place:

- Use an actual Map when building scan results
- set ScanResultComponent.status to optional to match current api
- create ComponentStatus type union
- replace optional Line properties with defined properties where feasible