### PR TITLE
feat: filter from `prepareRows` where not details

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "cSpell.words": ["mycommand", "prerun", "XEOL"],
+  "cSpell.words": ["mycommand", "padlen", "prerun", "rownum", "XEOL"],
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/service/line.ts
+++ b/src/service/line.ts
@@ -23,19 +23,16 @@ export function getStatusFromComponent(component: ScanResultComponent, daysEol: 
   }
 
   // If API fails to set status, we derive it based on other properties
-  let status: ComponentStatus = 'OK';
-
   if (daysEol === null) {
-    status = info.isEol ? 'EOL' : status;
-  } else if (daysEol > 0) {
-    // daysEol is positive means we're past the EOL date
-    status = 'EOL';
-  } else {
-    // daysEol is zero or negative means we haven't reached EOL yet
-    status = 'LTS';
+    return info.isEol ? 'EOL' : 'OK';
   }
 
-  return status;
+  if (daysEol > 0) {
+    // daysEol is positive means we're past the EOL date
+    return 'EOL';
+  }
+  // daysEol is zero or negative means we haven't reached EOL yet
+  return 'LTS';
 }
 
 export function daysBetween(date1: Date, date2: Date) {

--- a/src/service/line.ts
+++ b/src/service/line.ts
@@ -2,13 +2,40 @@ import { ux } from '@oclif/core';
 import type { ComponentStatus, ScanResultComponent } from './nes/modules/sbom.ts';
 
 export interface Line {
-  daysEol: number | undefined;
+  daysEol: number | null;
   purl: ScanResultComponent['purl'];
   info: {
     eolAt: Date | null;
     isEol: boolean;
   };
   status: ComponentStatus;
+  evidence: string;
+}
+
+export function getStatusFromComponent(component: ScanResultComponent, daysEol: number | null): ComponentStatus {
+  const { info } = component;
+
+  if (component.status) {
+    if (info.isEol && component.status !== 'EOL') {
+      throw new Error(`isEol is true but status is not EOL: ${component.purl}`);
+    }
+    return component.status;
+  }
+
+  // If API fails to set status, we derive it based on other properties
+  let status: ComponentStatus = 'OK';
+
+  if (daysEol === null) {
+    status = info.isEol ? 'EOL' : status;
+  } else if (daysEol > 0) {
+    // daysEol is positive means we're past the EOL date
+    status = 'EOL';
+  } else {
+    // daysEol is zero or negative means we haven't reached EOL yet
+    status = 'LTS';
+  }
+
+  return status;
 }
 
 export function daysBetween(date1: Date, date2: Date) {
@@ -16,11 +43,15 @@ export function daysBetween(date1: Date, date2: Date) {
   return Math.round((date2.getTime() - date1.getTime()) / msPerDay);
 }
 
-export function getMessageAndStatus(status: string, eolAt: Date | null) {
+export function getDaysEolFromEolAt(eolAt: Date | null): number | null {
+  return eolAt ? Math.abs(daysBetween(new Date(), eolAt)) : null;
+}
+
+export function getMessageAndStatus(status: string, daysEol: number | null) {
   let msg = '';
   let stat = '';
 
-  const stringifiedDaysEol = eolAt ? Math.abs(daysBetween(new Date(), eolAt)).toString() : 'unknown';
+  const stringifiedDaysEol = daysEol ? daysEol.toString() : 'unknown';
 
   switch (status) {
     case 'EOL': {
@@ -47,13 +78,9 @@ export function getMessageAndStatus(status: string, eolAt: Date | null) {
 }
 
 export function formatLine(l: Line, idx: number, ctx: { longest: number; total: number }) {
-  const { info, purl, status } = l;
+  const { daysEol, purl, status } = l;
 
-  if (info.isEol && status !== 'EOL') {
-    throw new Error(`isEol is true but status is not EOL: ${purl}`);
-  }
-
-  const { stat, msg } = getMessageAndStatus(status, info.eolAt);
+  const { stat, msg } = getMessageAndStatus(status, daysEol);
 
   const padlen = ctx.total.toString().length;
   const rownum = `${idx + 1}`.padStart(padlen, ' ');

--- a/test/commands/scan/eol.test.ts
+++ b/test/commands/scan/eol.test.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon';
 import { default as EolScan } from '../../../src/commands/scan/eol.ts';
 import { type Sbom, cdxgen, extractComponents, prepareRows } from '../../../src/service/eol/eol.svc.ts';
 import type { CdxCreator } from '../../../src/service/eol/eol.types.ts';
-import { type ScanResponseReport, buildScanResult } from '../../../src/service/nes/modules/sbom.ts';
+import { type ScanResponseReport, type ScanResult, buildScanResult } from '../../../src/service/nes/modules/sbom.ts';
 import { FetchMock } from '../../utils/mocks/fetch.mock.ts';
 import { InquirerMock } from '../../utils/mocks/ui.mock.ts';
 
@@ -58,8 +58,9 @@ describe('scan:eol', () => {
       strictEqual(output.error, undefined);
     }
 
-    // TODO: actually check the deeper result?
-    ok('components' in output.result);
+    const result = output.result as ScanResult;
+    ok('components' in result);
+    ok(result.components.size > 0);
     // console.log(stdout)
   });
 
@@ -77,7 +78,7 @@ const mocked = {
     components: [
       {
         info: {
-          eolAt: new Date(2019, 7, 24, 0, 0, 0, 0),
+          eolAt: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000), // 1 year ago
           isEol: true,
           isUnsafe: false,
         },


### PR DESCRIPTION
This PR was started due to this previous PR comment: https://github.com/herodevs/cli/pull/91#discussion_r1994903119

If details don't exist for a given Component (i.e., we don't have XEOL data), then we'll throw a debug warning and filter out those results from Lines.

Additionally:
- create getStatusFromComponent method to standardize how a status is derived from component info
- add specs for the same