### PR TITLE
chore: fix package versions and add token 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,7 @@ jobs:
             npm publish "$artifact" --tag latest --access public --provenance --dry-run
           done
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub release and tag
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
             npm publish "$artifact" --tag latest --access public --provenance --dry-run
           done
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
       - name: Create GitHub release and tag
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,12 +65,15 @@ jobs:
           cd packages/cli-${{ matrix.code-target }}
           npm ci
           npm run pack
-
+      - name: Debug Oclif output
+        shell: bash
+        run: |
+            ls -lah packages/cli-${{ matrix.code-target }}/dist
       - name: Upload CLI artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: cli-${{ matrix.code-target }}
-          path: ./packages/cli-${{ matrix.code-target }}/dist/hd-*
+          path: ./packages/cli-${{ matrix.code-target }}/dist/*.tgz
           if-no-files-found: error
   publish-cli:
     name: Publish
@@ -98,7 +101,8 @@ jobs:
         run: ls -lah artifacts/
       - name: Publish npm packages as latest # remove dry-run when ready
         run: |
-          for artifact in artifacts/*.tgz; do
+          ls -lah artifacts/  # Debug output
+          for artifact in artifacts/*; do
             echo "$artifact"
             npm publish "$artifact" --tag latest --access public --provenance --dry-run
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           ls -lah artifacts/  # Debug output
           for artifact in artifacts/*; do
             echo "$artifact"
-            npm publish "$artifact" --tag latest --access public --provenance --dry-run
+            npm publish "./$artifact" --tag latest --access public --provenance --dry-run
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: cli-${{ matrix.code-target }}
-          path: ./packages/cli-${{ matrix.code-target }}/dist/*.tgz
+          path: ./packages/cli-${{ matrix.code-target }}/dist/hd-*
           if-no-files-found: error
   publish-cli:
     name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
       - name: Create artifacts folder if it doesn't exist
         run: mkdir -p artifacts
       - name: Download CLI artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,11 @@ jobs:
           pattern: cli-*
           merge-multiple: true
           path: artifacts
+      - name: Debug artifact paths
+        run: ls -lah artifacts/
       - name: Publish npm packages as latest # remove dry-run when ready
         run: |
-          for artifact in artifacts/*; do
+          for artifact in artifacts/*.tgz; do
             echo "$artifact"
             npm publish "$artifact" --tag latest --access public --provenance --dry-run
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,8 @@ jobs:
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Debug artifacts before release
+        run: ls -lah artifacts/
       - name: Create GitHub release and tag
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         env:
@@ -118,6 +120,6 @@ jobs:
           tag_name: cli/v${{ needs.check.outputs.version }}
           draft: true  # Keep as a draft during dry run
           files: |
-            artifacts/cli-*
+            artifacts/*.tar.gz
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           name: CLI v${{ needs.check.outputs.version }}
           tag_name: cli/v${{ needs.check.outputs.version }}
-          draft: false
+          draft: true  # Keep as a draft during dry run
           files: |
             artifacts/cli-*
           fail_on_unmatched_files: true

--- a/packages/cli-darwin-arm64/package-lock.json
+++ b/packages/cli-darwin-arm64/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@herodevs/cli-darwin-arm64",
-    "version": "2.0.0",
+    "version": "1.0.0-beta",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@herodevs/cli-darwin-arm64",
-            "version": "2.0.0",
+            "version": "1.0.0-beta",
             "cpu": [
                 "arm64"
             ],

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@herodevs/cli-darwin-arm64",
-    "version": "2.0.0",
+    "version": "1.0.0-beta",
     "license": "MIT",
     "type": "commonjs",
     "repository": {

--- a/packages/cli-linux-x64/package-lock.json
+++ b/packages/cli-linux-x64/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@herodevs/cli-linux-x64",
-    "version": "2.0.0",
+    "version": "1.0.0-beta",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@herodevs/cli-linux-x64",
-            "version": "2.0.0",
+            "version": "1.0.0-beta",
             "cpu": [
                 "arm64"
             ],

--- a/packages/cli-linux-x64/package.json
+++ b/packages/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@herodevs/cli-linux-x64",
-    "version": "2.0.0",
+    "version": "1.0.0-beta",
     "license": "MIT",
     "type": "commonjs",
     "repository": {

--- a/packages/cli-win32-x64/package-lock.json
+++ b/packages/cli-win32-x64/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@herodevs/cli-win32-x64",
-    "version": "2.0.0",
+    "version": "1.0.0-beta",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@herodevs/cli-win32-x64",
-            "version": "2.0.0",
+            "version": "1.0.0-beta",
             "cpu": [
                 "arm64"
             ],

--- a/packages/cli-win32-x64/package.json
+++ b/packages/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@herodevs/cli-win32-x64",
-    "version": "2.0.0",
+    "version": "1.0.0-beta",
     "license": "MIT",
     "type": "commonjs",
     "repository": {

--- a/packages/cli-win32-x64/package.json
+++ b/packages/cli-win32-x64/package.json
@@ -20,7 +20,7 @@
     ],
     "scripts": {
         "prepack": "shx cp  -r ../../bin .",
-        "pack": "oclif pack tarballs --targets=win32-x64"
+        "pack": "oclif pack tarballs --targets=win32-x64 --no-xz"
     },
     "dependencies": {
         "@oclif/core": "^4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@herodevs/cli",
     "description": "The HeroDevs CLI",
-    "version": "2.0.0",
+    "version": "1.0.0-beta",
     "author": "HeroDevs, Inc",
     "type": "commonjs",
     "bin": {
@@ -26,8 +26,8 @@
     ],
     "license": "MIT",
     "optionalDependencies": {
-        "@herodevs/cli-darwin-arm64": "^2.0.0",
-        "@herodevs/cli-linux-x64": "^2.0.0",
-        "@herodevs/cli-win32-x64": "^2.0.0"
+        "@herodevs/cli-darwin-arm64": "^1.0.0-beta",
+        "@herodevs/cli-linux-x64": "^1.0.0-beta",
+        "@herodevs/cli-win32-x64": "^1.0.0-beta"
     }
 }


### PR DESCRIPTION
This PR has a few fixes that get the CI to run successfully:
- adds a dot in front of the artifact directory when running npm publish[1]
- adds `--no-xz` to the windows pack command: otherwise npm publish fails for windows.[2]
- changes the GitHub release files to `artifacts/*.tar.gz`: otherwise creating a GitHub release fails.[3]
- switched to `draft: true` for the GitHub release action
- updates the package version numbers to `1.0.0-beta`

There are also a few changes that seem reasonable but may not be required
- sets the `registry-url` in the `publish-cli` step
- switch the `NODE_AUTH_TOKEN` from `HD_CLI_NPM_TOKEN` to `GITHUB_TOKEN` (does the HD one even exist anymore?)

## A Note About the GitHub Release Action

This PR resulted in a draft GitHub Release getting created. I manually deleted it. The version was missing although it did appear to have the cli artifacts uploaded.

[1]https://github.com/npm/cli/issues/2796#issuecomment-816857548
[2]https://github.com/herodevs/cli/actions/runs/13938050304/job/39009787801
[3]https://github.com/herodevs/cli/actions/runs/13938152376/job/39010037052