### PR TITLE
chore: remove plugins and hooks

### DIFF
--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -34,13 +34,6 @@
         "bin": "hd",
         "dirname": "hd",
         "commands": "../../dist/commands",
-        "plugins": [
-            "@oclif/plugin-help",
-            "@oclif/plugin-plugins"
-        ],
-        "hooks": {
-            "prerun": "../../dist/hooks/prerun/CommandContextHook"
-        },
         "macos": {
             "identifier": "com.herodevs.cli"
         },

--- a/packages/cli-linux-x64/package.json
+++ b/packages/cli-linux-x64/package.json
@@ -34,13 +34,6 @@
         "bin": "hd",
         "dirname": "hd",
         "commands": "../../dist/commands",
-        "plugins": [
-            "@oclif/plugin-help",
-            "@oclif/plugin-plugins"
-        ],
-        "hooks": {
-            "prerun": "../../dist/hooks/prerun/CommandContextHook"
-        },
         "topicSeparator": " "
     }
 }

--- a/packages/cli-win32-x64/package.json
+++ b/packages/cli-win32-x64/package.json
@@ -34,13 +34,6 @@
         "bin": "hd",
         "dirname": "hd",
         "commands": "../../dist/commands",
-        "plugins": [
-            "@oclif/plugin-help",
-            "@oclif/plugin-plugins"
-        ],
-        "hooks": {
-            "prerun": "../../dist/hooks/prerun/CommandContextHook"
-        },
         "topicSeparator": " "
     }
 }


### PR DESCRIPTION
I don't think that the platform-specific binaries need the plugins and hooks. They're in the root package.json already.