### PR TITLE
feat: move eol status handling to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install -g @herodevs/cli
 $ hd COMMAND
 running command...
 $ hd (--version)
-@herodevs/cli/1.0.0-beta.2 darwin-arm64 node-v22.13.0
+@herodevs/cli/1.1.0-beta.1 darwin-arm64 node-v22.14.0
 $ hd --help [COMMAND]
 USAGE
   $ hd COMMAND
@@ -380,7 +380,7 @@ EXAMPLES
   $ hd report committers --csv
 ```
 
-_See code: [src/commands/report/committers.ts](https://github.com/herodevs/cli/blob/v1.0.0-beta.2/src/commands/report/committers.ts)_
+_See code: [src/commands/report/committers.ts](https://github.com/herodevs/cli/blob/v1.1.0-beta.1/src/commands/report/committers.ts)_
 
 ## `hd report purls`
 
@@ -414,7 +414,7 @@ EXAMPLES
   $ hd report purls --save --csv
 ```
 
-_See code: [src/commands/report/purls.ts](https://github.com/herodevs/cli/blob/v1.0.0-beta.2/src/commands/report/purls.ts)_
+_See code: [src/commands/report/purls.ts](https://github.com/herodevs/cli/blob/v1.1.0-beta.1/src/commands/report/purls.ts)_
 
 ## `hd scan eol`
 
@@ -441,7 +441,7 @@ EXAMPLES
   $ hd scan eol --file=path/to/sbom.json
 ```
 
-_See code: [src/commands/scan/eol.ts](https://github.com/herodevs/cli/blob/v1.0.0-beta.2/src/commands/scan/eol.ts)_
+_See code: [src/commands/scan/eol.ts](https://github.com/herodevs/cli/blob/v1.1.0-beta.1/src/commands/scan/eol.ts)_
 
 ## `hd scan sbom`
 
@@ -469,5 +469,5 @@ EXAMPLES
   $ hd scan sbom --file=path/to/sbom.json
 ```
 
-_See code: [src/commands/scan/sbom.ts](https://github.com/herodevs/cli/blob/v1.0.0-beta.2/src/commands/scan/sbom.ts)_
+_See code: [src/commands/scan/sbom.ts](https://github.com/herodevs/cli/blob/v1.1.0-beta.1/src/commands/scan/sbom.ts)_
 <!-- commandsstop -->

--- a/src/api/queries/nes/sbom.ts
+++ b/src/api/queries/nes/sbom.ts
@@ -12,6 +12,8 @@ export const M_SCAN = {
                 isEol
                 isUnsafe
                 eolAt
+                daysEol
+                status
               }
             } 
             diagnostics
@@ -21,6 +23,9 @@ export const M_SCAN = {
             warnings {
               purl
               type
+              message
+              error
+              diagnostics
             }
           }
         }

--- a/src/api/types/nes.types.ts
+++ b/src/api/types/nes.types.ts
@@ -13,18 +13,29 @@ export interface ScanResponseReport {
   diagnostics?: Record<string, unknown>;
   message: string;
   success: boolean;
+  warnings?: ScanWarning[];
 }
 
-export type ComponentStatus = 'EOL' | 'LTS' | 'OK';
+export const VALID_STATUSES = ['UNKNOWN', 'OK', 'EOL', 'LTS'] as const;
+export type ComponentStatus = 'EOL' | 'LTS' | 'OK' | 'UNKNOWN';
 
 export interface ScanResultComponent {
   info: {
     eolAt: Date | null;
     isEol: boolean;
+    daysEol: number | null;
     isUnsafe: boolean;
+    status: ComponentStatus;
   };
   purl: string;
-  status?: ComponentStatus;
+}
+
+export interface ScanWarning {
+  purl: string;
+  message: string;
+  type?: string;
+  error?: unknown;
+  diagnostics?: Record<string, unknown>;
 }
 
 export interface ScanResult {
@@ -32,4 +43,5 @@ export interface ScanResult {
   diagnostics?: Record<string, unknown>;
   message: string;
   success: boolean;
+  warnings: ScanWarning[];
 }

--- a/src/api/types/nes.types.ts
+++ b/src/api/types/nes.types.ts
@@ -17,7 +17,7 @@ export interface ScanResponseReport {
 }
 
 export const VALID_STATUSES = ['UNKNOWN', 'OK', 'EOL', 'LTS'] as const;
-export type ComponentStatus = 'EOL' | 'LTS' | 'OK' | 'UNKNOWN';
+export type ComponentStatus = (typeof VALID_STATUSES)[number];
 
 export interface ScanResultComponent {
   info: {

--- a/src/service/eol/eol.svc.ts
+++ b/src/service/eol/eol.svc.ts
@@ -1,6 +1,5 @@
 import { NesApolloClient } from '../../api/nes/nes.client.ts';
 import type { ScanResult } from '../../api/types/nes.types.ts';
-import type { ComponentStatus } from '../../api/types/nes.types.ts';
 import { debugLogger } from '../../service/log.svc.ts';
 import type { Line } from '../line.svc.ts';
 import { extractPurls } from '../purls.svc.ts';

--- a/src/service/eol/eol.svc.ts
+++ b/src/service/eol/eol.svc.ts
@@ -1,7 +1,7 @@
 import { NesApolloClient } from '../../api/nes/nes.client.ts';
-import type { ComponentStatus, ScanResult } from '../../api/types/nes.types.ts';
+import type { ScanResult } from '../../api/types/nes.types.ts';
+import type { ComponentStatus } from '../../api/types/nes.types.ts';
 import { debugLogger } from '../../service/log.svc.ts';
-import { getDaysEolFromEolAt, getStatusFromComponent } from '../line.svc.ts';
 import type { Line } from '../line.svc.ts';
 import { extractPurls } from '../purls.svc.ts';
 import { type Sbom, createBomFromDir } from './cdx.svc.ts';
@@ -72,17 +72,15 @@ export async function submitScan(purls: string[]): Promise<ScanResult> {
  * The idea being that each row can easily be used for
  * processing and/or rendering.
  */
-export async function prepareRows(purls: string[], scan: ScanResult): Promise<Line[]> {
+export async function prepareRows(purls: string[], scan: ScanResult, withStatus: string[]): Promise<Line[]> {
   const lines: Line[] = [];
 
   for (const purl of purls) {
     const details = scan.components.get(purl);
 
     if (!details) {
-      // In this case, the purl string is in the generated sbom, but the NES/XEOL api has no data
-      // TODO: add UNKNOWN Component Status, create new line, and create flag to show/hide unknown results
-      debugLogger(`Unknown status: ${purl}.`);
-      continue;
+      // The api should create a default component with status UNKNOWN even if the purl is not found
+      throw new Error(`API failed to return details for: ${purl}.`);
     }
 
     const { info } = details;
@@ -92,21 +90,16 @@ export async function prepareRows(purls: string[], scan: ScanResult): Promise<Li
       info.eolAt = new Date(info.eolAt);
     }
 
-    const daysEol: number | null = getDaysEolFromEolAt(info.eolAt);
-
-    const status: ComponentStatus = getStatusFromComponent(details, daysEol);
-
-    const showOk = process.env.SHOW_OK === 'true';
-
-    if (!showOk && status === 'OK') {
+    if (!withStatus.includes(details.info.status)) {
+      debugLogger('Skipping', details.info.status, 'withStatus', withStatus);
       continue;
     }
 
     lines.push({
-      daysEol,
+      daysEol: details.info.daysEol,
       info,
       purl,
-      status,
+      status: details.info.status,
     });
   }
 

--- a/src/service/line.svc.ts
+++ b/src/service/line.svc.ts
@@ -10,36 +10,9 @@ export interface Line {
   status: ComponentStatus;
 }
 
-export function getStatusFromComponent(component: ScanResultComponent, daysEol: number | null): ComponentStatus {
-  const { info } = component;
-
-  if (component.status) {
-    if (info.isEol && component.status && component.status !== 'EOL') {
-      throw new Error(`isEol is true but status is not EOL: ${component.purl}`);
-    }
-    return component.status;
-  }
-
-  // If API fails to set status, we derive it based on other properties
-  if (daysEol === null) {
-    return info.isEol ? 'EOL' : 'OK';
-  }
-
-  if (daysEol > 0) {
-    // daysEol is positive means we're past the EOL date
-    return 'EOL';
-  }
-  // daysEol is zero or negative means we haven't reached EOL yet
-  return 'LTS';
-}
-
 export function daysBetween(date1: Date, date2: Date) {
   const msPerDay = 1000 * 60 * 60 * 24 + 15; // milliseconds in a day plus 15 ms
   return Math.round((date2.getTime() - date1.getTime()) / msPerDay);
-}
-
-export function getDaysEolFromEolAt(eolAt: Date | null): number | null {
-  return eolAt ? Math.abs(daysBetween(new Date(), eolAt)) : null;
 }
 
 export function getMessageAndStatus(status: string, daysEol: number | null) {
@@ -65,6 +38,13 @@ export function getMessageAndStatus(status: string, daysEol: number | null) {
       stat = 'OK';
       break;
     }
+
+    case 'UNKNOWN': {
+      stat = 'UNKNOWN';
+      msg = 'No data found';
+      break;
+    }
+
     default:
       throw new Error(`Unknown status: ${status}`);
   }

--- a/src/service/nes/nes.svc.ts
+++ b/src/service/nes/nes.svc.ts
@@ -13,10 +13,12 @@ export const buildScanResult = (scan: ScanResponseReport): ScanResult => {
   for (const c of scan.components) {
     components.set(c.purl, c);
   }
+
   return {
     components,
     message: scan.message,
     success: true,
+    warnings: scan.warnings || [],
   };
 };
 

--- a/test/service/eol.svc.test.ts
+++ b/test/service/eol.svc.test.ts
@@ -18,8 +18,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([createMockComponent(purl, 'EOL')]);
 
         // Act
-        process.env.SHOW_OK = 'true';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL', 'OK']);
 
         // Assert
         assert.equal(rows.length, 1);
@@ -32,8 +31,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([createMockComponent(purl, 'EOL', new Date())]);
 
         // Act
-        process.env.SHOW_OK = 'true';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL', 'OK']);
 
         // Assert
         assert.equal(rows.length, 1);
@@ -47,8 +45,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([component]);
 
         // Act
-        process.env.SHOW_OK = 'true';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL', 'OK']);
 
         // Assert
         assert.equal(rows.length, 1);
@@ -63,8 +60,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([component]);
 
         // Act
-        process.env.SHOW_OK = 'true';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL', 'OK']);
 
         // Assert
         assert.equal(rows.length, 1);
@@ -76,16 +72,16 @@ describe('eol.svc', () => {
         // Arrange
         const purl = 'pkg:npm/test@1.0.0';
         const eolDate = new Date();
-        eolDate.setDate(eolDate.getDate() - 30); // 30 days ago
-        const scan = createMockScan([createMockComponent(purl, 'EOL', eolDate)]);
+        eolDate.setDate(eolDate.getDate() - 30);
+        const component = createMockComponent(purl, 'EOL', eolDate, 30);
+        const scan = createMockScan([component]);
 
         // Act
-        process.env.SHOW_OK = 'true';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL', 'OK']);
 
         // Assert
         assert.equal(rows.length, 1);
-        assert.equal(rows[0].daysEol, 30);
+        assert.equal(rows[0].daysEol, component.info.daysEol);
       });
     });
 
@@ -96,8 +92,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([createMockComponent(purl)]);
 
         // Act
-        process.env.SHOW_OK = 'false';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL']);
 
         // Assert
         assert.equal(rows.length, 0);
@@ -109,8 +104,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([createMockComponent(purl, 'OK')]);
 
         // Act
-        process.env.SHOW_OK = 'false';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL']);
 
         // Assert
         assert.equal(rows.length, 0);
@@ -122,8 +116,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([createMockComponent(purl, 'EOL', new Date())]);
 
         // Act
-        process.env.SHOW_OK = 'false';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL']);
 
         // Assert
         assert.equal(rows.length, 1);
@@ -136,8 +129,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([createMockComponent('pkg:npm/other@1.0.0')]);
 
         // Act
-        process.env.SHOW_OK = 'false';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL']);
 
         // Assert
         assert.equal(rows.length, 0);
@@ -149,8 +141,7 @@ describe('eol.svc', () => {
         const scan = createMockScan([]);
 
         // Act
-        process.env.SHOW_OK = 'false';
-        const rows = await prepareRows([purl], scan);
+        const rows = await prepareRows([purl], scan, ['EOL']);
 
         // Assert
         assert.equal(rows.length, 0);

--- a/test/service/line.svc.test.ts
+++ b/test/service/line.svc.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import type { ScanResultComponent } from '../../src/api/types/nes.types.ts';
-import { daysBetween, formatLine, getMessageAndStatus, getStatusFromComponent } from '../../src/service/line.svc.ts';
+import { daysBetween, formatLine, getMessageAndStatus } from '../../src/service/line.svc.ts';
 import type { Line } from '../../src/service/line.svc.ts';
 
 describe('line', () => {
@@ -45,57 +44,6 @@ describe('line', () => {
 
     it('should throw on unknown status', () => {
       assert.throws(() => getMessageAndStatus('INVALID', null), /Unknown status: INVALID/);
-    });
-  });
-
-  describe('getStatusFromComponent', () => {
-    const baseComponent: ScanResultComponent = {
-      purl: 'pkg:npm/test@1.0.0',
-      info: {
-        eolAt: null,
-        isEol: false,
-        isUnsafe: false,
-      },
-    };
-
-    it('should use component status if provided', () => {
-      const component = { ...baseComponent, status: 'LTS' as const };
-      assert.equal(getStatusFromComponent(component, -30), 'LTS');
-    });
-
-    it('should throw if isEol is true but status is not EOL', () => {
-      const component = {
-        ...baseComponent,
-        status: 'OK' as const,
-        info: { ...baseComponent.info, isEol: true },
-      };
-      assert.throws(() => getStatusFromComponent(component, null), /isEol is true but status is not EOL/);
-    });
-
-    describe('when status is not provided', () => {
-      it('should return EOL if daysEol is null and isEol is true', () => {
-        const component = {
-          ...baseComponent,
-          info: { ...baseComponent.info, isEol: true },
-        };
-        assert.equal(getStatusFromComponent(component, null), 'EOL');
-      });
-
-      it('should return OK if daysEol is null and isEol is false', () => {
-        const component = { ...baseComponent };
-        assert.equal(getStatusFromComponent(component, null), 'OK');
-      });
-
-      it('should return LTS if daysEol is zero or negative (future/today)', () => {
-        const component = { ...baseComponent };
-        assert.equal(getStatusFromComponent(component, 0), 'LTS');
-        assert.equal(getStatusFromComponent(component, -30), 'LTS');
-      });
-
-      it('should return EOL if daysEol is positive (past date)', () => {
-        const component = { ...baseComponent };
-        assert.equal(getStatusFromComponent(component, 30), 'EOL');
-      });
     });
   });
 

--- a/test/utils/mocks/scan-result-component.mock.ts
+++ b/test/utils/mocks/scan-result-component.mock.ts
@@ -1,22 +1,24 @@
-import type { SbomEntry } from '../../../src/service/eol/eol.types.ts';
-import type { ScanResult, ScanResultComponent } from '../../../src/service/nes/modules/sbom.ts';
+import type { ScanResult, ScanResultComponent } from '../../../src/api/types/nes.types.ts';
 
 export const createMockComponent = (
   purl: string,
   status: 'OK' | 'EOL' | 'LTS' = 'OK',
   eolAt: Date | null = null,
+  daysEol: number | null = null,
 ): ScanResultComponent => ({
   purl,
   info: {
     eolAt,
     isEol: status === 'EOL',
     isUnsafe: false,
+    status,
+    daysEol,
   },
-  status,
 });
 
 export const createMockScan = (components: ScanResultComponent[]): ScanResult => ({
   components: new Map(components.map((c) => [c.purl, c])),
   message: 'Test scan',
   success: true,
+  warnings: [],
 });


### PR DESCRIPTION
This PR ensures that the monorepo api is the source of truth for the status of a given purl (EOL, UNKNOWN, LTS, or OK).

The `scan eol` command is still gated so it cannot be used in production. We will enable that command once the api is deployed to the monorepo.