### PR TITLE
feat: create error service

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,5 @@
 import * as apollo from '@apollo/client/core/index.js';
+import { ApolloError } from '../service/error.svc.ts';
 
 export interface ApolloHelper {
   mutate<T, V extends apollo.OperationVariables>(
@@ -26,7 +27,6 @@ export const createApollo = (url: string) =>
     ]),
   });
 
-export class ApolloError extends Error {}
 export class ApolloClient implements ApolloHelper {
   #apollo: apollo.ApolloClient<apollo.NormalizedCacheObject>;
 
@@ -35,24 +35,24 @@ export class ApolloClient implements ApolloHelper {
   }
 
   async mutate<T, V extends apollo.OperationVariables>(mutation: apollo.DocumentNode, variables?: V) {
-    return this.#apollo
-      .mutate<T, V>({
+    try {
+      return await this.#apollo.mutate<T, V>({
         mutation,
         variables,
-      })
-      .catch((error) => {
-        throw new ApolloError('Failed GQL Mutation');
       });
+    } catch (error: unknown) {
+      throw new ApolloError('GraphQL mutation failed', error);
+    }
   }
 
   async query<T, V extends apollo.OperationVariables | undefined>(query: apollo.DocumentNode, variables?: V) {
-    return this.#apollo
-      .query<T>({
+    try {
+      return await this.#apollo.query<T>({
         query,
         variables,
-      })
-      .catch((error) => {
-        throw new ApolloError('Failed GQL Query');
       });
+    } catch (error) {
+      throw new ApolloError('GraphQL query failed', error);
+    }
   }
 }

--- a/src/commands/report/committers.ts
+++ b/src/commands/report/committers.ts
@@ -12,6 +12,7 @@ import {
   groupCommitsByMonth,
   parseGitLogOutput,
 } from '../../service/committers.svc.ts';
+import { getErrorMessage, isErrnoException } from '../../service/error.svc.ts';
 
 export default class Committers extends Command {
   static override description = 'Generate report of committers to a git repository';
@@ -51,7 +52,7 @@ export default class Committers extends Command {
 
     try {
       // Generate structured report data
-      const entries = this.fetchGitCommitData(sinceDate);
+      const entries = await this.fetchGitCommitData(sinceDate);
       this.log('Fetched %d commit entries', entries.length);
       const reportData = this.generateReportData(entries);
 
@@ -59,8 +60,12 @@ export default class Committers extends Command {
       if (isJson) {
         // JSON mode
         if (save) {
-          fs.writeFileSync(path.resolve('nes.committers.json'), JSON.stringify(reportData, null, 2));
-          this.log('Report written to json');
+          try {
+            fs.writeFileSync(path.resolve('nes.committers.json'), JSON.stringify(reportData, null, 2));
+            this.log('Report written to json');
+          } catch (error) {
+            this.error(`Failed to save JSON report: ${getErrorMessage(error)}`);
+          }
         }
         return reportData;
       }
@@ -68,8 +73,12 @@ export default class Committers extends Command {
         // CSV mode
         const csvOutput = formatAsCsv(reportData);
         if (save) {
-          fs.writeFileSync(path.resolve('nes.committers.csv'), csvOutput);
-          this.log('Report written to csv');
+          try {
+            fs.writeFileSync(path.resolve('nes.committers.csv'), csvOutput);
+            this.log('Report written to csv');
+          } catch (error) {
+            this.error(`Failed to save CSV report: ${getErrorMessage(error)}`);
+          }
         } else {
           this.log(csvOutput);
         }
@@ -78,15 +87,18 @@ export default class Committers extends Command {
       // Text mode
       const textOutput = formatAsText(reportData);
       if (save) {
-        fs.writeFileSync(path.resolve('nes.committers.txt'), textOutput);
-        this.log('Report written to txt');
+        try {
+          fs.writeFileSync(path.resolve('nes.committers.txt'), textOutput);
+          this.log('Report written to txt');
+        } catch (error) {
+          this.error(`Failed to save text report: ${getErrorMessage(error)}`);
+        }
       } else {
         this.log(textOutput);
       }
       return textOutput;
     } catch (error) {
-      this.error(`Failed to generate report: ${(error as Error).message}`);
-      throw error;
+      this.error(`Failed to generate report: ${getErrorMessage(error)}`);
     }
   }
 
@@ -122,32 +134,37 @@ export default class Committers extends Command {
    * Fetches git commit data with month and author information
    * @param sinceDate - Date range for git log
    */
-  private fetchGitCommitData(sinceDate: string): CommitEntry[] {
-    try {
-      const logProcess = spawnSync(
-        'git',
-        [
-          'log',
-          '--all', // Include committers on all branches in the repo
-          '--format="%ad|%an"', // Format: date|author
-          '--date=format:%Y-%m', // Format date as YYYY-MM
-          `--since="${sinceDate}"`,
-        ],
-        { encoding: 'utf-8' },
-      );
+  private async fetchGitCommitData(sinceDate: string): Promise<CommitEntry[]> {
+    const logProcess = spawnSync(
+      'git',
+      [
+        'log',
+        '--all', // Include committers on all branches in the repo
+        '--format="%ad|%an"', // Format: date|author
+        '--date=format:%Y-%m', // Format date as YYYY-MM
+        `--since="${sinceDate}"`,
+      ],
+      { encoding: 'utf-8' },
+    );
 
-      if (logProcess.error) {
-        throw new Error(`Git command failed: ${logProcess.error.message}`);
+    if (logProcess.error) {
+      if (isErrnoException(logProcess.error)) {
+        if (logProcess.error.code === 'ENOENT') {
+          this.error('Git command not found. Please ensure git is installed and available in your PATH.');
+        }
+        this.error(`Git command failed: ${getErrorMessage(logProcess.error)}`);
       }
-
-      if (!logProcess.stdout) {
-        return [];
-      }
-
-      return parseGitLogOutput(logProcess.stdout);
-    } catch (error) {
-      this.error(`Failed to fetch git data: ${(error as Error).message}`);
-      return []; // This line won't execute due to this.error() above
+      this.error(`Git command failed: ${getErrorMessage(logProcess.error)}`);
     }
+
+    if (logProcess.status !== 0) {
+      this.error(`Git command failed with status ${logProcess.status}: ${logProcess.stderr}`);
+    }
+
+    if (!logProcess.stdout) {
+      return [];
+    }
+
+    return parseGitLogOutput(logProcess.stdout);
   }
 }

--- a/src/commands/report/committers.ts
+++ b/src/commands/report/committers.ts
@@ -91,7 +91,7 @@ export default class Committers extends Command {
           fs.writeFileSync(path.resolve('nes.committers.txt'), textOutput);
           this.log('Report written to txt');
         } catch (error) {
-          this.error(`Failed to save text report: ${getErrorMessage(error)}`);
+          this.error(`Failed to save txt report: ${getErrorMessage(error)}`);
         }
       } else {
         this.log(textOutput);

--- a/src/commands/report/committers.ts
+++ b/src/commands/report/committers.ts
@@ -52,7 +52,7 @@ export default class Committers extends Command {
 
     try {
       // Generate structured report data
-      const entries = await this.fetchGitCommitData(sinceDate);
+      const entries = this.fetchGitCommitData(sinceDate);
       this.log('Fetched %d commit entries', entries.length);
       const reportData = this.generateReportData(entries);
 
@@ -134,7 +134,7 @@ export default class Committers extends Command {
    * Fetches git commit data with month and author information
    * @param sinceDate - Date range for git log
    */
-  private async fetchGitCommitData(sinceDate: string): Promise<CommitEntry[]> {
+  private fetchGitCommitData(sinceDate: string): CommitEntry[] {
     const logProcess = spawnSync(
       'git',
       [

--- a/src/commands/scan/sbom.ts
+++ b/src/commands/scan/sbom.ts
@@ -113,11 +113,11 @@ export default class ScanSbom extends Command {
         }),
       ];
 
-    const workerProcess = spawn('node', [join(import.meta.url, '../../service/eol/sbom.worker.js'), ...args], {
-      stdio: 'ignore',
-      detached: true,
-      env: { ...process.env },
-    });
+      const workerProcess = spawn('node', [join(import.meta.url, '../../service/eol/sbom.worker.js'), ...args], {
+        stdio: 'ignore',
+        detached: true,
+        env: { ...process.env },
+      });
 
       workerProcess.unref();
     } catch (error) {

--- a/src/service/error.svc.ts
+++ b/src/service/error.svc.ts
@@ -1,0 +1,32 @@
+export const isError = (error: unknown): error is Error => {
+  return error instanceof Error;
+};
+
+export const isErrnoException = (error: unknown): error is NodeJS.ErrnoException => {
+  return isError(error) && 'code' in error;
+};
+
+export const isApolloError = (error: unknown): error is ApolloError => {
+  return error instanceof ApolloError;
+};
+
+export const getErrorMessage = (error: unknown): string => {
+  if (isError(error)) {
+    return error.message;
+  }
+  return 'Unknown error';
+};
+
+export class ApolloError extends Error {
+  public readonly originalError?: unknown;
+
+  constructor(message: string, original?: unknown) {
+    if (isError(original)) {
+      super(`${message}: ${original.message}`);
+    } else {
+      super(`${message}: ${String(original)}`);
+    }
+    this.name = 'ApolloError';
+    this.originalError = original;
+  }
+}


### PR DESCRIPTION
Leverage oclif's built-in `this.error` functionality where feasible.

Add a few utility methods for getting the `message` out of Errors more easily.