### PR TITLE
feat: add purls flag to eol scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,14 @@ Scan a given sbom for EOL data
 
 ```
 USAGE
-  $ hd scan eol [--json] [-f <value>] [-d <value>] [-s] [-a] [-c]
+  $ hd scan eol [--json] [-f <value>] [-p <value>] [-d <value>] [-s] [-a] [-c]
 
 FLAGS
   -a, --all                 Show all components (default is EOL and LTS only)
   -c, --getCustomerSupport  Get Never-Ending Support for End-of-Life components
   -d, --dir=<value>         The directory to scan in order to create a cyclonedx sbom
   -f, --file=<value>        The file path of an existing cyclonedx sbom to scan for EOL
+  -p, --purls=<value>       The file path of a list of purls to scan for EOL
   -s, --save                Save the generated SBOM as nes.sbom.json in the scanned directory
 
 GLOBAL FLAGS
@@ -141,6 +142,8 @@ EXAMPLES
   $ hd scan eol --dir=./my-project
 
   $ hd scan eol --file=path/to/sbom.json
+
+  $ hd scan eol --purls=path/to/purls.json
 
   $ hd scan eol -a --dir=./my-project
 ```

--- a/src/commands/report/purls.ts
+++ b/src/commands/report/purls.ts
@@ -83,9 +83,7 @@ export default class ReportPurls extends Command {
       }
 
       // Return wrapped object with metadata
-      return {
-        purls,
-      };
+      return { purls };
     } catch (error) {
       this.error(`Failed to generate PURLs: ${getErrorMessage(error)}`);
     }

--- a/src/service/purls.svc.ts
+++ b/src/service/purls.svc.ts
@@ -31,3 +31,33 @@ export async function extractPurls(sbom: Sbom): Promise<string[]> {
   const { components: comps } = sbom;
   return comps.map((c) => c.purl) ?? [];
 }
+
+/**
+ * Parse a purls file in either JSON or text format, including the format of
+ * nes.purls.json - { purls: [ 'pkg:npm/express@4.18.2', 'pkg:npm/react@18.3.1' ] }
+ * or a text file with one purl per line.
+ */
+export function parsePurlsFile(purlsFileString: string): string[] {
+  try {
+    const parsed = JSON.parse(purlsFileString);
+
+    if (parsed && Array.isArray(parsed.purls)) {
+      return parsed.purls;
+    }
+
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch {
+    const lines = purlsFileString
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && line.startsWith('pkg:'));
+
+    if (lines.length > 0) {
+      return lines;
+    }
+  }
+
+  throw new Error('Invalid purls file: must be either JSON with purls array or text file with one purl per line');
+}

--- a/test/service/purls.svc.test.ts
+++ b/test/service/purls.svc.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { formatCsvValue, getPurlOutput } from '../../src/service/purls.svc.ts';
+import { formatCsvValue, getPurlOutput, parsePurlsFile } from '../../src/service/purls.svc.ts';
 
 describe('getPurlOutput', () => {
   describe('json output', () => {
@@ -47,5 +47,75 @@ describe('formatCsvValue', () => {
 
   it('should handle empty string', () => {
     assert.strictEqual(formatCsvValue(''), '');
+  });
+});
+
+describe('parsePurlsFile', () => {
+  describe('JSON format', () => {
+    it('should parse nes.purls.json format', () => {
+      const input = JSON.stringify({
+        purls: ['pkg:npm/@apollo/client@3.13.5', 'pkg:npm/react@18.2.0'],
+      });
+      const result = parsePurlsFile(input);
+      assert.deepStrictEqual(result, ['pkg:npm/@apollo/client@3.13.5', 'pkg:npm/react@18.2.0']);
+    });
+
+    it('should parse direct JSON array', () => {
+      const input = JSON.stringify(['pkg:npm/express@4.18.2', 'pkg:npm/typescript@5.0.0']);
+      const result = parsePurlsFile(input);
+      assert.deepStrictEqual(result, ['pkg:npm/express@4.18.2', 'pkg:npm/typescript@5.0.0']);
+    });
+  });
+
+  describe('text format', () => {
+    it('should parse text file with one purl per line', () => {
+      const input = `pkg:npm/react@18.2.0
+pkg:npm/typescript@5.0.0`;
+      const result = parsePurlsFile(input);
+      assert.deepStrictEqual(result, ['pkg:npm/react@18.2.0', 'pkg:npm/typescript@5.0.0']);
+    });
+
+    it('should handle empty lines and whitespace', () => {
+      const input = `
+        pkg:npm/react@18.2.0
+        
+        pkg:npm/typescript@5.0.0
+      `;
+      const result = parsePurlsFile(input);
+      assert.deepStrictEqual(result, ['pkg:npm/react@18.2.0', 'pkg:npm/typescript@5.0.0']);
+    });
+
+    it('should filter out invalid lines', () => {
+      const input = `
+        not-a-purl
+        pkg:npm/react@18.2.0
+        also-not-a-purl
+        pkg:npm/typescript@5.0.0
+      `;
+      const result = parsePurlsFile(input);
+      assert.deepStrictEqual(result, ['pkg:npm/react@18.2.0', 'pkg:npm/typescript@5.0.0']);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw error for invalid JSON', () => {
+      const input = '{ invalid json }';
+      assert.throws(() => parsePurlsFile(input), {
+        message: 'Invalid purls file: must be either JSON with purls array or text file with one purl per line',
+      });
+    });
+
+    it('should throw error for empty file', () => {
+      assert.throws(() => parsePurlsFile(''), {
+        message: 'Invalid purls file: must be either JSON with purls array or text file with one purl per line',
+      });
+    });
+
+    it('should throw error for file with no valid purls', () => {
+      const input = 'not-a-purl\nstill-not-a-purl';
+      assert.throws(() => parsePurlsFile(input), {
+        message: 'Invalid purls file: must be either JSON with purls array or text file with one purl per line',
+      });
+    });
   });
 });


### PR DESCRIPTION
This flag allows eol scan to directly consume a list of purls to send to our api.

Users can still generate an sbom or use an existing sbom to get a list of purls.

This feature allows `scan eol` to be useable by clients who want to derive a list of purls using a method besides cyclonedx sboms.

This feature also allows `scan eol` to `dog food` the output of `report purls -s`.