### PR TITLE
feat: custom node 18 fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "shx rm -rf dist && npm run clean:files && shx rm -rf node_modules",
     "clean:files": "shx rm -f nes.**.csv nes.**.json nes.**.text",
     "dev": "npm run build && ./bin/dev.js",
-    "dev:debug": "npm run build && DEBUG=* ./bin/dev.js",
+    "dev:debug": "npm run build && DEBUG=oclif:* ./bin/dev.js",
     "format": "biome format --write",
     "lint": "biome lint --write",
     "postpack": "shx rm -f oclif.manifest.json",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,19 +1,23 @@
 import * as apollo from '@apollo/client/core/index.js';
 import { ApolloError } from '../service/error.svc.ts';
+import { debugLogger } from '../service/log.svc.ts';
+import { lookup } from 'node:dns/promises';
+import https from 'node:https';
 
 export interface ApolloHelper {
   mutate<T, V extends apollo.OperationVariables>(
     mutation: apollo.DocumentNode,
-    variables?: V,
+    variables?: V
   ): Promise<apollo.FetchResult<T>>;
   query<T, V extends apollo.OperationVariables | undefined = undefined>(
     query: apollo.DocumentNode,
-    variables?: V,
+    variables?: V
   ): Promise<apollo.ApolloQueryResult<T>>;
 }
 
-export const createApollo = (url: string) =>
-  new apollo.ApolloClient({
+export const createApollo = (url: string) => {
+  debugLogger('Creating Apollo client with URL: %s', url);
+  return new apollo.ApolloClient({
     cache: new apollo.InMemoryCache({
       addTypename: false,
     }),
@@ -23,9 +27,72 @@ export const createApollo = (url: string) =>
     link: apollo.ApolloLink.from([
       new apollo.HttpLink({
         uri: url,
+        fetch: async (uri, options) => {
+          debugLogger('Making fetch request to: %s', uri);
+          debugLogger('Fetch options: %O', {
+            method: options?.method,
+            headers: options?.headers,
+            body: options?.body
+              ? JSON.parse(options.body as string)
+              : undefined,
+          });
+          try {
+            const urlObj = new URL(uri.toString());
+            const ipv4 = await lookup(urlObj.hostname, { family: 4 });
+            debugLogger('Resolved to IPv4: %s', ipv4.address);
+
+            return new Promise((resolve, reject) => {
+              const headers = options?.headers as
+                | Record<string, string>
+                | undefined;
+              const req = https.request(
+                {
+                  host: ipv4.address,
+                  port: urlObj.port || '443',
+                  path: '/graphql',
+                  method: options?.method,
+                  headers: {
+                    ...headers,
+                    Host: urlObj.hostname,
+                  },
+                  servername: urlObj.hostname,
+                },
+                (res) => {
+                  const chunks: Buffer[] = [];
+                  res.on('data', (chunk) => chunks.push(chunk));
+                  res.on('end', () => {
+                    const response = new Response(Buffer.concat(chunks), {
+                      status: res.statusCode,
+                      statusText: res.statusMessage,
+                      headers: res.headers as Record<string, string>,
+                    });
+                    resolve(response);
+                  });
+                }
+              );
+
+              req.on('error', (error) => {
+                debugLogger('Request error: %O', error);
+                reject(error);
+              });
+
+              if (options?.body) {
+                req.write(options.body);
+                req.end();
+              } else {
+                req.end();
+              }
+            });
+          } catch (error) {
+            debugLogger('Fetch error: %O', error);
+            throw error;
+          }
+        },
+        credentials: 'same-origin',
       }),
     ]),
   });
+};
 
 export class ApolloClient implements ApolloHelper {
   #apollo: apollo.ApolloClient<apollo.NormalizedCacheObject>;
@@ -34,24 +101,44 @@ export class ApolloClient implements ApolloHelper {
     this.#apollo = createApollo(url);
   }
 
-  async mutate<T, V extends apollo.OperationVariables>(mutation: apollo.DocumentNode, variables?: V) {
+  async mutate<T, V extends apollo.OperationVariables>(
+    mutation: apollo.DocumentNode,
+    variables?: V
+  ) {
     try {
+      debugLogger('Executing mutation with variables: %O', variables);
       return await this.#apollo.mutate<T, V>({
         mutation,
         variables,
+        context: {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
       });
     } catch (error: unknown) {
+      debugLogger('Mutation error: %O', error);
       throw new ApolloError('GraphQL mutation failed', error);
     }
   }
 
-  async query<T, V extends apollo.OperationVariables | undefined>(query: apollo.DocumentNode, variables?: V) {
+  async query<T, V extends apollo.OperationVariables | undefined>(
+    query: apollo.DocumentNode,
+    variables?: V
+  ) {
     try {
+      debugLogger('Executing query with variables: %O', variables);
       return await this.#apollo.query<T>({
         query,
         variables,
+        context: {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
       });
     } catch (error) {
+      debugLogger('Query error: %O', error);
       throw new ApolloError('GraphQL query failed', error);
     }
   }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,5 @@
 import { lookup } from 'node:dns/promises';
+import http from 'node:http';
 import https from 'node:https';
 import * as apollo from '@apollo/client/core/index.js';
 import { ApolloError } from '../service/error.svc.ts';
@@ -33,17 +34,20 @@ const createCustomFetch = () => {
 
       return new Promise((resolve, reject) => {
         const headers = init?.headers as Record<string, string> | undefined;
-        const req = https.request(
+        const isHttps = urlObj.protocol === 'https:';
+        const client = isHttps ? https : http;
+
+        const req = client.request(
           {
             host: ipv4.address,
-            port: urlObj.port || '443',
+            port: urlObj.port || (isHttps ? '443' : '80'),
             path: '/graphql',
             method: init?.method,
             headers: {
               ...headers,
               Host: urlObj.hostname,
             },
-            servername: urlObj.hostname,
+            ...(isHttps ? { servername: urlObj.hostname } : {}),
           },
           (res) => {
             const chunks: Buffer[] = [];

--- a/src/api/nes/nes.client.ts
+++ b/src/api/nes/nes.client.ts
@@ -30,25 +30,6 @@ export class NesApolloClient implements NesClient {
   }
 }
 
-interface BatchConfig {
-  avgPurlLength: number; // Average length of a PURL string
-  jsonOverhead: number; // JSON overhead per item (quotes, commas, etc)
-  totalOverhead: number; // Total overhead for query structure
-  byteLimit: number; // Server byte limit
-}
-
-const DEFAULT_BATCH_CONFIG: BatchConfig = {
-  avgPurlLength: 30, // characters
-  jsonOverhead: 10, // characters per item
-  totalOverhead: 200, // characters for query structure
-  byteLimit: 100_000, // slightly below server limit of 102400
-};
-
-function calculateOptimalBatchSize(config: BatchConfig = DEFAULT_BATCH_CONFIG): number {
-  const bytesPerItem = (config.avgPurlLength + config.jsonOverhead) * 2; // UTF-8 approximation
-  return Math.floor((config.byteLimit - config.totalOverhead) / bytesPerItem);
-}
-
 async function submitScan(purls: string[]): Promise<ScanResult> {
   // NOTE: GRAPHQL_HOST is set in `./bin/dev.js` or tests
   const host = process.env.GRAPHQL_HOST || 'https://api.nes.herodevs.com';
@@ -70,60 +51,22 @@ function combineScanResults(results: ScanResult[]): ScanResult {
     for (const component of result.components.values()) {
       combinedResults.components.set(component.purl, component);
     }
-
     combinedResults.warnings.push(...result.warnings);
-
-    if (result.message) {
-      if (combinedResults.message) {
-        combinedResults.message += `\n${result.message}`;
-      } else {
-        combinedResults.message = result.message;
-      }
-    }
-
     combinedResults.success = combinedResults.success && result.success;
   }
 
   return combinedResults;
 }
 
-function logBatchStart(purls: string[], batches: string[][], batchSize: number, config?: BatchConfig): void {
-  const bytesPerBatch =
-    ((config?.avgPurlLength ?? DEFAULT_BATCH_CONFIG.avgPurlLength) +
-      (config?.jsonOverhead ?? DEFAULT_BATCH_CONFIG.jsonOverhead)) *
-      batchSize +
-    (config?.totalOverhead ?? DEFAULT_BATCH_CONFIG.totalOverhead);
+const BATCH_SIZE = 1000;
 
-  debugLogger(
-    'Submitting %d purls in %d batches (batch size: %d, estimated bytes per batch: %d)',
-    purls.length,
-    batches.length,
-    batchSize,
-    bytesPerBatch,
-  );
-}
-
-function logBatchProgress(batch: string[], index: number, config?: BatchConfig): void {
-  const estimatedSize =
-    batch.reduce((sum, purl) => sum + purl.length, 0) * 2 +
-    (config?.totalOverhead ?? DEFAULT_BATCH_CONFIG.totalOverhead);
-
-  debugLogger('Starting batch %d with %d purls (estimated size: %d bytes)', index + 1, batch.length, estimatedSize);
-}
-
-function logBatchCompletion(successfulResults: ScanResult[], errors: string[]): void {
-  debugLogger(
-    'Completed scan with %d successful batches and %d failed batches',
-    successfulResults.length,
-    errors.length,
-  );
-}
-
-export async function batchSubmitPurls(purls: string[], config?: BatchConfig): Promise<ScanResult> {
+export async function batchSubmitPurls(purls: string[]): Promise<ScanResult> {
   try {
-    const batchSize = calculateOptimalBatchSize(config);
-    const batches = splitIntoBatches(purls, batchSize);
-    logBatchStart(purls, batches, batchSize, config);
+    const batches = Array.from(
+      { length: Math.ceil(purls.length / BATCH_SIZE) },
+      (_, i) => purls.slice(i * BATCH_SIZE, (i + 1) * BATCH_SIZE)
+    );
+    debugLogger('Processing %d batches', batches.length);
 
     const successfulResults: ScanResult[] = [];
     const errors: string[] = [];
@@ -131,40 +74,38 @@ export async function batchSubmitPurls(purls: string[], config?: BatchConfig): P
     await Promise.all(
       batches.map(async (batch, index) => {
         try {
-          logBatchProgress(batch, index, config);
+          debugLogger('Starting batch %d', index + 1);
           const result = await submitScan(batch);
           debugLogger('Batch %d completed successfully', index + 1);
           successfulResults.push(result);
         } catch (error) {
           debugLogger('Batch %d failed: %s', index + 1, error);
-          errors.push(`Batch ${index + 1}: ${error instanceof Error ? error.message : String(error)}`);
+          errors.push(
+            `Batch ${index + 1}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
         }
-      }),
+      })
     );
 
     if (successfulResults.length === 0) {
-      throw new Error(`All batches failed:\n ${errors.join('\n')}`);
+      throw new Error('All batches failed:\n' + errors.join('\n'));
     }
 
     const combinedResults = combineScanResults(successfulResults);
-
     if (errors.length > 0) {
       combinedResults.success = false;
-      combinedResults.message = combinedResults.message
-        ? `${combinedResults.message}\nErrors encountered:\n${errors.join('\n')}`
-        : `Errors encountered:\n${errors.join('\n')}`;
+      combinedResults.message = `Errors encountered:\n${errors.join('\n')}`;
     }
 
-    logBatchCompletion(successfulResults, errors);
     return combinedResults;
   } catch (error) {
     debugLogger('Fatal error in batchSubmitPurls: %s', error);
-    throw new Error(`Failed to process purls: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(
+      `Failed to process purls: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
   }
-}
-
-export function splitIntoBatches(array: string[], batchSize: number): string[][] {
-  return Array.from({ length: Math.ceil(array.length / batchSize) }, (_, i) =>
-    array.slice(i * batchSize, (i + 1) * batchSize),
-  );
 }

--- a/src/api/nes/nes.client.ts
+++ b/src/api/nes/nes.client.ts
@@ -30,6 +30,25 @@ export class NesApolloClient implements NesClient {
   }
 }
 
+interface BatchConfig {
+  avgPurlLength: number; // Average length of a PURL string
+  jsonOverhead: number; // JSON overhead per item (quotes, commas, etc)
+  totalOverhead: number; // Total overhead for query structure
+  byteLimit: number; // Server byte limit
+}
+
+const DEFAULT_BATCH_CONFIG: BatchConfig = {
+  avgPurlLength: 30, // characters
+  jsonOverhead: 10, // characters per item
+  totalOverhead: 200, // characters for query structure
+  byteLimit: 100_000, // slightly below server limit of 102400
+};
+
+function calculateOptimalBatchSize(config: BatchConfig = DEFAULT_BATCH_CONFIG): number {
+  const bytesPerItem = (config.avgPurlLength + config.jsonOverhead) * 2; // UTF-8 approximation
+  return Math.floor((config.byteLimit - config.totalOverhead) / bytesPerItem);
+}
+
 async function submitScan(purls: string[]): Promise<ScanResult> {
   // NOTE: GRAPHQL_HOST is set in `./bin/dev.js` or tests
   const host = process.env.GRAPHQL_HOST || 'https://api.nes.herodevs.com';
@@ -68,30 +87,60 @@ function combineScanResults(results: ScanResult[]): ScanResult {
   return combinedResults;
 }
 
-export async function batchSubmitPurls(purls: string[], batchSize = 500): Promise<ScanResult> {
-  try {
-    const batches = splitIntoBatches(purls, batchSize);
-    debugLogger('Submitting %d purls in %d batches of size %d', purls.length, batches.length, batchSize);
+function logBatchStart(purls: string[], batches: string[][], batchSize: number, config?: BatchConfig): void {
+  const bytesPerBatch =
+    ((config?.avgPurlLength ?? DEFAULT_BATCH_CONFIG.avgPurlLength) +
+      (config?.jsonOverhead ?? DEFAULT_BATCH_CONFIG.jsonOverhead)) *
+      batchSize +
+    (config?.totalOverhead ?? DEFAULT_BATCH_CONFIG.totalOverhead);
 
-    const results = await Promise.allSettled(
-      batches.map((batch, index) => {
-        debugLogger('Starting batch %d with %d purls', index + 1, batch.length);
-        return submitScan(batch);
-      }),
-    );
+  debugLogger(
+    'Submitting %d purls in %d batches (batch size: %d, estimated bytes per batch: %d)',
+    purls.length,
+    batches.length,
+    batchSize,
+    bytesPerBatch,
+  );
+}
+
+function logBatchProgress(batch: string[], index: number, config?: BatchConfig): void {
+  const estimatedSize =
+    batch.reduce((sum, purl) => sum + purl.length, 0) * 2 +
+    (config?.totalOverhead ?? DEFAULT_BATCH_CONFIG.totalOverhead);
+
+  debugLogger('Starting batch %d with %d purls (estimated size: %d bytes)', index + 1, batch.length, estimatedSize);
+}
+
+function logBatchCompletion(successfulResults: ScanResult[], errors: string[]): void {
+  debugLogger(
+    'Completed scan with %d successful batches and %d failed batches',
+    successfulResults.length,
+    errors.length,
+  );
+}
+
+export async function batchSubmitPurls(purls: string[], config?: BatchConfig): Promise<ScanResult> {
+  try {
+    const batchSize = calculateOptimalBatchSize(config);
+    const batches = splitIntoBatches(purls, batchSize);
+    logBatchStart(purls, batches, batchSize, config);
 
     const successfulResults: ScanResult[] = [];
     const errors: string[] = [];
 
-    for (const [index, result] of results.entries()) {
-      if (result.status === 'fulfilled') {
-        debugLogger('Batch %d completed successfully', index + 1);
-        successfulResults.push(result.value);
-      } else {
-        debugLogger('Batch %d failed: %s', index + 1, result.reason);
-        errors.push(`Batch ${index + 1}: ${result.reason}`);
-      }
-    }
+    await Promise.all(
+      batches.map(async (batch, index) => {
+        try {
+          logBatchProgress(batch, index, config);
+          const result = await submitScan(batch);
+          debugLogger('Batch %d completed successfully', index + 1);
+          successfulResults.push(result);
+        } catch (error) {
+          debugLogger('Batch %d failed: %s', index + 1, error);
+          errors.push(`Batch ${index + 1}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }),
+    );
 
     if (successfulResults.length === 0) {
       throw new Error(`All batches failed:\n ${errors.join('\n')}`);
@@ -106,12 +155,7 @@ export async function batchSubmitPurls(purls: string[], batchSize = 500): Promis
         : `Errors encountered:\n${errors.join('\n')}`;
     }
 
-    debugLogger(
-      'Completed scan with %d successful batches and %d failed batches',
-      successfulResults.length,
-      errors.length,
-    );
-
+    logBatchCompletion(successfulResults, errors);
     return combinedResults;
   } catch (error) {
     debugLogger('Fatal error in batchSubmitPurls: %s', error);

--- a/src/api/nes/nes.client.ts
+++ b/src/api/nes/nes.client.ts
@@ -1,7 +1,8 @@
 import type * as apollo from '@apollo/client/core/index.js';
 
 import { ApolloClient } from '../../api/client.ts';
-import type { ScanResult } from '../../api/types/nes.types.ts';
+import type { ScanResult, ScanResultComponent } from '../../api/types/nes.types.ts';
+import { debugLogger } from '../../service/log.svc.ts';
 import { SbomScanner } from '../../service/nes/nes.svc.ts';
 
 export interface NesClient {
@@ -29,14 +30,97 @@ export class NesApolloClient implements NesClient {
   }
 }
 
-/**
- * Uses the purls from the sbom to run the scan.
- */
-export async function submitScan(purls: string[]): Promise<ScanResult> {
+async function submitScan(purls: string[]): Promise<ScanResult> {
   // NOTE: GRAPHQL_HOST is set in `./bin/dev.js` or tests
   const host = process.env.GRAPHQL_HOST || 'https://api.nes.herodevs.com';
   const path = process.env.GRAPHQL_PATH || '/graphql';
   const url = host + path;
   const client = new NesApolloClient(url);
   return client.scan.sbom(purls);
+}
+
+function combineScanResults(results: ScanResult[]): ScanResult {
+  const combinedResults: ScanResult = {
+    components: new Map<string, ScanResultComponent>(),
+    message: '',
+    success: true,
+    warnings: [],
+  };
+
+  for (const result of results) {
+    for (const component of result.components.values()) {
+      combinedResults.components.set(component.purl, component);
+    }
+
+    combinedResults.warnings.push(...result.warnings);
+
+    if (result.message) {
+      if (combinedResults.message) {
+        combinedResults.message += `\n${result.message}`;
+      } else {
+        combinedResults.message = result.message;
+      }
+    }
+
+    combinedResults.success = combinedResults.success && result.success;
+  }
+
+  return combinedResults;
+}
+
+export async function batchSubmitPurls(purls: string[], batchSize = 500): Promise<ScanResult> {
+  try {
+    const batches = splitIntoBatches(purls, batchSize);
+    debugLogger('Submitting %d purls in %d batches of size %d', purls.length, batches.length, batchSize);
+
+    const results = await Promise.allSettled(
+      batches.map((batch, index) => {
+        debugLogger('Starting batch %d with %d purls', index + 1, batch.length);
+        return submitScan(batch);
+      }),
+    );
+
+    const successfulResults: ScanResult[] = [];
+    const errors: string[] = [];
+
+    for (const [index, result] of results.entries()) {
+      if (result.status === 'fulfilled') {
+        debugLogger('Batch %d completed successfully', index + 1);
+        successfulResults.push(result.value);
+      } else {
+        debugLogger('Batch %d failed: %s', index + 1, result.reason);
+        errors.push(`Batch ${index + 1}: ${result.reason}`);
+      }
+    }
+
+    if (successfulResults.length === 0) {
+      throw new Error(`All batches failed:\n ${errors.join('\n')}`);
+    }
+
+    const combinedResults = combineScanResults(successfulResults);
+
+    if (errors.length > 0) {
+      combinedResults.success = false;
+      combinedResults.message = combinedResults.message
+        ? `${combinedResults.message}\nErrors encountered:\n${errors.join('\n')}`
+        : `Errors encountered:\n${errors.join('\n')}`;
+    }
+
+    debugLogger(
+      'Completed scan with %d successful batches and %d failed batches',
+      successfulResults.length,
+      errors.length,
+    );
+
+    return combinedResults;
+  } catch (error) {
+    debugLogger('Fatal error in batchSubmitPurls: %s', error);
+    throw new Error(`Failed to process purls: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export function splitIntoBatches(array: string[], batchSize: number): string[][] {
+  return Array.from({ length: Math.ceil(array.length / batchSize) }, (_, i) =>
+    array.slice(i * batchSize, (i + 1) * batchSize),
+  );
 }

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { Command, Flags, ux } from '@oclif/core';
-import { submitScan } from '../../api/nes/nes.client.ts';
+import { batchSubmitPurls } from '../../api/nes/nes.client.ts';
 import type { ScanResult, ScanResultComponent } from '../../api/types/nes.types.ts';
 import type { Sbom } from '../../service/eol/cdx.svc.ts';
 import { getErrorMessage, isErrnoException } from '../../service/error.svc.ts';
@@ -78,7 +78,7 @@ export default class ScanEol extends Command {
   private async getScan(flags: Record<string, string>, config: Command['config']): Promise<ScanResult> {
     if (flags.purls) {
       const purls = this.getPurlsFromFile(flags.purls);
-      return submitScan(purls);
+      return batchSubmitPurls(purls);
     }
 
     const sbom = await ScanSbom.loadSbom(flags, config);
@@ -106,7 +106,7 @@ export default class ScanEol extends Command {
       this.error(`Failed to extract purls from sbom. ${getErrorMessage(error)}`);
     }
     try {
-      scan = await submitScan(purls);
+      scan = await batchSubmitPurls(purls);
     } catch (error) {
       this.error(`Failed to submit scan to NES from sbom. ${getErrorMessage(error)}`);
     }

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -77,6 +77,7 @@ export default class ScanEol extends Command {
 
   private async getScan(flags: Record<string, string>, config: Command['config']): Promise<ScanResult> {
     if (flags.purls) {
+      ux.action.start(`Scanning purls from ${flags.purls}`);
       const purls = this.getPurlsFromFile(flags.purls);
       return batchSubmitPurls(purls);
     }

--- a/test/api/nes.client.test.ts
+++ b/test/api/nes.client.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { createBatches } from '../../src/api/nes/nes.client.ts';
+
+describe('createBatches', () => {
+  it('should handle empty array', () => {
+    const result = createBatches([], 1000);
+    assert.deepStrictEqual(result, []);
+  });
+
+  it('should create single batch when items length is less than batch size', () => {
+    const items = ['a', 'b', 'c'];
+    const result = createBatches(items, 5);
+    assert.deepStrictEqual(result, [['a', 'b', 'c']]);
+  });
+
+  it('should create single batch when items length equals batch size', () => {
+    const items = ['a', 'b', 'c', 'd', 'e'];
+    const result = createBatches(items, 5);
+    assert.deepStrictEqual(result, [['a', 'b', 'c', 'd', 'e']]);
+  });
+
+  it('should create multiple batches when items length exceeds batch size', () => {
+    const items = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+    const result = createBatches(items, 3);
+    assert.deepStrictEqual(result, [['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i'], ['j']]);
+  });
+
+  it('should handle batch size of 1', () => {
+    const items = ['a', 'b', 'c'];
+    const result = createBatches(items, 1);
+    assert.deepStrictEqual(result, [['a'], ['b'], ['c']]);
+  });
+});


### PR DESCRIPTION
## Screenshot of the solution in action

![Screenshot 2025-03-28 at 2 58 51 PM](https://github.com/user-attachments/assets/4450cb4d-ef34-4089-a0e1-aa95574283bd)

## Bug: Scan eol fails on Node 18 when pointed to prod

![Screenshot 2025-03-28 at 1 08 23 PM](https://github.com/user-attachments/assets/a5438f39-e401-42fe-b112-2e013221b454)

**Cause:** I'm not entirely sure. I think it has something to do with the fetch implementation in Node v18.

**Solution:** create bespoke fetch implementation that is only used on node 18. I tried using `undici`, but it just wasn't configurable in a reasonable way for this purpose. I also tried simply using the `--dns-result-order=ipv4first` flag on Node 18 but that didn't work either.