### PR TITLE
chore: revert to async import to fix logs

### DIFF
--- a/src/service/eol/cdx.svc.ts
+++ b/src/service/eol/cdx.svc.ts
@@ -1,6 +1,5 @@
-import { createBom } from '@cyclonedx/cdxgen';
 import { debugLogger } from '../../service/log.svc.ts';
-import type { CdxGenOptions } from './eol.svc.ts';
+import type { CdxCreator, CdxGenOptions } from './eol.svc.ts';
 
 export interface SbomEntry {
   group: string;
@@ -70,11 +69,31 @@ export const SBOM_DEFAULT__OPTIONS = {
 };
 
 /**
- * Lazy loads cdxgen (for ESM purposes), scans
- * `directory`, and returns the `bomJson` property.
+ * Scans a directory and returns the SBOM JSON.
  */
-export const createBomFromDir = async (directory: string, opts: CdxGenOptions = {}) => {
-  const sbom = await createBom(directory, { ...SBOM_DEFAULT__OPTIONS, ...opts });
+export async function createBomFromDir(directory: string, opts: CdxGenOptions = {}) {
+  const { createBom } = await getCdxGen();
+  const sbom = await createBom?.(directory, { ...SBOM_DEFAULT__OPTIONS, ...opts });
   debugLogger('Successfully generated SBOM');
   return sbom?.bomJson;
-};
+}
+
+// use a value holder, for easier mocking
+export const cdxgen: {
+  createBom: CdxCreator | undefined;
+} = { createBom: undefined };
+export async function getCdxGen() {
+  if (cdxgen.createBom) {
+    return cdxgen;
+  }
+
+  const ogEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = undefined;
+  try {
+    cdxgen.createBom = (await import('@cyclonedx/cdxgen')).createBom;
+  } finally {
+    process.env.NODE_ENV = ogEnv;
+  }
+
+  return cdxgen;
+}


### PR DESCRIPTION
The cdxgen createBom function uses debug logging unless the NODE_ENV is production.

We can (and should) revisit setting NODE_ENV appropriately to manage logs.