### PR TITLE
chore: ee/exclude tarballs from npm

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -35,9 +35,22 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
 
-  release:
+  test:
     runs-on: ubuntu-latest
     needs: check
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version-file: '.nvmrc'
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm run test:e2e
+
+  upload-assets:
+    runs-on: ubuntu-latest
+    needs: [check, test]
     permissions:
       contents: write
       id-token: write
@@ -48,11 +61,9 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
-      # Build and test
+      # Build
       - run: npm ci
       - run: npm run build
-      - run: npm test
-      - run: npm run test:e2e
 
       # Build platform-specific tarballs
       - name: Install linux toolchain
@@ -98,7 +109,23 @@ jobs:
             --targets=linux-x64,win32-x64,darwin-arm64 \
             --ignore-missing
 
-      # # NPM Release
+  npm-publish:
+    runs-on: ubuntu-latest
+    needs: [check, test, upload-assets]
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Clean build for npm publishing
+      - run: npm ci
+      - run: npm run build
+
+      # NPM Release
       - name: Create NPM release
         run: npm publish --tag ${{ inputs.channel }} --provenance --access public ${{ inputs.dry-run == true && '--dry-run' || '' }}
         env:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -138,4 +138,3 @@ jobs:
         run: npm publish --tag ${{ inputs.channel }} --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
-      

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -125,8 +125,17 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      # NPM Release
-      - name: Create NPM release
-        run: npm publish --tag ${{ inputs.channel }} --provenance --access public ${{ inputs.dry-run == true && '--dry-run' || '' }}
+      # Dry run NPM publish
+      - name: Dry run NPM publish
+        if: ${{ inputs.dry-run }}
+        run: npm publish --tag ${{ inputs.channel }} --provenance --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
+  
+      # NPM Release
+      - name: Create NPM release
+        if: ${{ !inputs.dry-run }}
+        run: npm publish --tag ${{ inputs.channel }} --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
+      

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -21,8 +21,7 @@ permissions:
   contents: read
 
 jobs:
-  check:
-    name: Check version
+  check-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -37,7 +36,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: check
+    needs: check-version
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
@@ -50,7 +49,7 @@ jobs:
 
   upload-assets:
     runs-on: ubuntu-latest
-    needs: [check, test]
+    needs: [check-version, test]
     permissions:
       contents: write
       id-token: write
@@ -111,7 +110,7 @@ jobs:
 
   npm-publish:
     runs-on: ubuntu-latest
-    needs: [check, test, upload-assets]
+    needs: [check-version, test, upload-assets]
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
The previous workflow failed to exclude the tarballs from the npm publish step. This PR fixes that issue.