### PR TITLE
chore: fix how we set channels in s3

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -86,22 +86,22 @@ jobs:
         run: |
           mkdir -p dist/linux
           npx oclif pack tarballs --targets=linux-x64 --no-xz
-          mv dist/*linux*.tar.gz dist/linux/
-          mv dist/*linux*.buildmanifest dist/linux/
+          mv dist/hd-v*-linux-x64.tar.gz dist/linux/
+          mv dist/hd-v*-linux-x64-buildmanifest dist/linux/
 
       - name: Build win32-x64 tarball
         run: |
           mkdir -p dist/windows
           npx oclif pack tarballs --targets=win32-x64 --no-xz
-          mv dist/*win32*.tar.gz dist/windows/
-          mv dist/*win32*.buildmanifest dist/windows/
+          mv dist/hd-v*-win32-x64.tar.gz dist/windows/
+          mv dist/hd-v*-win32-x64-buildmanifest dist/windows/
 
       - name: Build darwin-arm64 tarball
         run: |
           mkdir -p dist/darwin
           npx oclif pack tarballs --targets=darwin-arm64 --no-xz
-          mv dist/*darwin*.tar.gz dist/darwin/
-          mv dist/*darwin*.buildmanifest dist/darwin/
+          mv dist/hd-v*-darwin-arm64.tar.gz dist/darwin/
+          mv dist/hd-v*-darwin-arm64-buildmanifest dist/darwin/
 
       # Move tarballs to dist root
       - name: Consolidate tarballs

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -83,13 +83,33 @@ jobs:
           sudo apt install nsis p7zip-full p7zip-rar -y
 
       - name: Build linux-x64 tarball
-        run: npx oclif pack tarballs --targets=linux-x64 --no-xz
+        run: |
+          mkdir -p dist/linux
+          cd dist/linux
+          npx oclif pack tarballs --targets=linux-x64 --no-xz
+          cd ../..
 
       - name: Build win32-x64 tarball
-        run: npx oclif pack tarballs --targets=win32-x64 --no-xz
+        run: |
+          mkdir -p dist/windows
+          cd dist/windows
+          npx oclif pack tarballs --targets=win32-x64 --no-xz
+          cd ../..
 
       - name: Build darwin-arm64 tarball
-        run: npx oclif pack tarballs --targets=darwin-arm64 --no-xz
+        run: |
+          mkdir -p dist/darwin
+          cd dist/darwin
+          npx oclif pack tarballs --targets=darwin-arm64 --no-xz
+          cd ../..
+
+      # Move tarballs to dist root
+      - name: Consolidate tarballs
+        run: |
+          mv dist/linux/* dist/
+          mv dist/windows/* dist/
+          mv dist/darwin/* dist/
+          rm -rf dist/linux dist/windows dist/darwin
 
       # S3 Distribution
       - name: Configure AWS credentials

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -31,8 +31,20 @@ jobs:
       - name: Get version
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - name: Determine Oclif channel
+        id: oclif-channel
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *"-beta"* ]]; then
+            echo "oclif_channel=beta" >> $GITHUB_OUTPUT
+          elif [[ "$VERSION" == *"-alpha"* ]]; then
+            echo "oclif_channel=alpha" >> $GITHUB_OUTPUT
+          else
+            echo "oclif_channel=stable" >> $GITHUB_OUTPUT
+          fi
     outputs:
       version: ${{ steps.version.outputs.version }}
+      oclif_channel: ${{ steps.oclif-channel.outputs.oclif_channel }}
 
   test:
     runs-on: ubuntu-latest
@@ -101,8 +113,8 @@ jobs:
 
           # Promote to channel
           npx oclif promote \
-            --channel=${{ inputs.channel }} \
-            --version=${{ needs.check.outputs.version }} \
+            --channel=${{ needs.check-version.outputs.oclif_channel }} \
+            --version=${{ needs.check-version.outputs.version }} \
             --sha=${{ github.sha }} \
             --indexes \
             --targets=linux-x64,win32-x64,darwin-arm64 \
@@ -132,8 +144,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
   
       # NPM Release
-      - name: Create NPM release
-        if: ${{ !inputs.dry-run }}
-        run: npm publish --tag ${{ inputs.channel }} --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
+      # - name: Create NPM release
+      #   if: ${{ !inputs.dry-run }}
+      #   run: npm publish --tag ${{ inputs.channel }} --provenance --access public
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -106,11 +106,15 @@ jobs:
             --targets=linux-x64,win32-x64,darwin-arm64 \
             --no-xz
 
+          # Get shortened SHA (first 7 characters)
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          echo "Using shortened SHA: $SHORT_SHA"
+
           # Promote to channel
           npx oclif promote \
             --channel=${{ needs.check-version.outputs.oclif_channel }} \
             --version=${{ needs.check-version.outputs.version }} \
-            --sha=${{ github.sha }} \
+            --sha=$SHORT_SHA \
             --indexes \
             --targets=linux-x64,win32-x64,darwin-arm64 \
             --ignore-missing

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -143,8 +143,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
   
       # NPM Release
-      # - name: Create NPM release
-      #   if: ${{ !inputs.dry-run }}
-      #   run: npm publish --tag ${{ inputs.channel }} --provenance --access public
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}
+      - name: Create NPM release
+        if: ${{ !inputs.dry-run }}
+        run: npm publish --tag ${{ inputs.channel }} --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.HD_CLI_NPM_TOKEN }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -82,34 +82,9 @@ jobs:
           sudo apt update
           sudo apt install nsis p7zip-full p7zip-rar -y
 
-      - name: Build linux-x64 tarball
+      - name: Build all tarballs in parallel
         run: |
-          mkdir -p dist/linux
-          npx oclif pack tarballs --targets=linux-x64 --no-xz
-          mv dist/hd-v*-linux-x64.tar.gz dist/linux/
-          mv dist/hd-v*-linux-x64-buildmanifest dist/linux/
-
-      - name: Build win32-x64 tarball
-        run: |
-          mkdir -p dist/windows
-          npx oclif pack tarballs --targets=win32-x64 --no-xz
-          mv dist/hd-v*-win32-x64.tar.gz dist/windows/
-          mv dist/hd-v*-win32-x64-buildmanifest dist/windows/
-
-      - name: Build darwin-arm64 tarball
-        run: |
-          mkdir -p dist/darwin
-          npx oclif pack tarballs --targets=darwin-arm64 --no-xz
-          mv dist/hd-v*-darwin-arm64.tar.gz dist/darwin/
-          mv dist/hd-v*-darwin-arm64-buildmanifest dist/darwin/
-
-      # Move tarballs to dist root
-      - name: Consolidate tarballs
-        run: |
-          mv dist/linux/* dist/
-          mv dist/windows/* dist/
-          mv dist/darwin/* dist/
-          rm -rf dist/linux dist/windows dist/darwin
+          npx oclif pack tarballs --targets=linux-x64,win32-x64,darwin-arm64 --no-xz --parallel
 
       # S3 Distribution
       - name: Configure AWS credentials

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -85,23 +85,23 @@ jobs:
       - name: Build linux-x64 tarball
         run: |
           mkdir -p dist/linux
-          cd dist/linux
           npx oclif pack tarballs --targets=linux-x64 --no-xz
-          cd ../..
+          mv dist/*linux*.tar.gz dist/linux/
+          mv dist/*linux*.buildmanifest dist/linux/
 
       - name: Build win32-x64 tarball
         run: |
           mkdir -p dist/windows
-          cd dist/windows
           npx oclif pack tarballs --targets=win32-x64 --no-xz
-          cd ../..
+          mv dist/*win32*.tar.gz dist/windows/
+          mv dist/*win32*.buildmanifest dist/windows/
 
       - name: Build darwin-arm64 tarball
         run: |
           mkdir -p dist/darwin
-          cd dist/darwin
           npx oclif pack tarballs --targets=darwin-arm64 --no-xz
-          cd ../..
+          mv dist/*darwin*.tar.gz dist/darwin/
+          mv dist/*darwin*.buildmanifest dist/darwin/
 
       # Move tarballs to dist root
       - name: Consolidate tarballs


### PR DESCRIPTION
This PR fixes a few quirks with how we were uploading to s3:
- Ensures we use a short commit hash in the `oclif promote --sha=<short-hash>` to meet oclif's expectations
- Ensure the darwin and linux tarballs don't contain the contents of the other tarballs by using `--parallel`
- Ensure the channel used by oclif can be beta even if we're _not_ doing a dry run

- [Green CI Run](https://github.com/herodevs/cli/actions/runs/14275524079)
- Screenshot showing beta channel in s3
![Screenshot 2025-04-04 at 5 58 26 PM](https://github.com/user-attachments/assets/84d411de-bcd1-44cf-a296-c6d226a9e0ef)
