### PR TITLE
feat: add vuln count to table output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@oclif/core": "^4",
         "@oclif/plugin-help": "^6",
         "@oclif/plugin-update": "^4",
-        "cli-table3": "^0.6.5",
+        "@oclif/table": "^0.4.7",
         "graphql": "^16.8.1",
         "packageurl-js": "^2.0.1"
       },
@@ -1647,16 +1647,6 @@
       "integrity": "sha512-i5GE2Dk5ekdlK1TR7SugY4LWRrKSfb5T1Qn4unpIMbfxoeGKERKQ59HG3iYewacGD10SR7UzevfPnh6my4tNmQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)",
       "optional": true
-    },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -5727,21 +5717,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-table3": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
-      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-truncate": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@oclif/core": "^4",
     "@oclif/plugin-help": "^6",
     "@oclif/plugin-update": "^4",
-    "cli-table3": "^0.6.5",
+    "@oclif/table": "^0.4.7",
     "graphql": "^16.8.1",
     "packageurl-js": "^2.0.1"
   },

--- a/src/api/nes/nes.client.ts
+++ b/src/api/nes/nes.client.ts
@@ -102,6 +102,7 @@ export const processBatch = async ({
   }
 
   debugLogger('Processing batch %d of %d', page, totalPages);
+  debugLogger('ScanID: %s', previousScanId);
   const result = await submitScan(batch, {
     ...scanOptions,
     page,

--- a/src/api/queries/nes/sbom.ts
+++ b/src/api/queries/nes/sbom.ts
@@ -3,9 +3,9 @@ import { gql } from '@apollo/client/core/core.cjs';
 export const M_SCAN = {
   gql: gql`
     mutation EolScan($input: InsightsEolScanInput!) {
-        insights {
-          scan {
-            eol(input: $input) {
+      insights {
+        scan {
+          eol(input: $input) {
             components {
               purl
               info {
@@ -14,9 +14,10 @@ export const M_SCAN = {
                 eolAt
                 daysEol
                 status
-                vulnCount
+                # TODO: uncomment vulnCount once backend changes are deployed 
+                # vulnCount
               }
-            } 
+            }
             diagnostics
             message
             scanId

--- a/src/api/queries/nes/sbom.ts
+++ b/src/api/queries/nes/sbom.ts
@@ -14,6 +14,7 @@ export const M_SCAN = {
                 eolAt
                 daysEol
                 status
+                vulnCount
               }
             } 
             diagnostics

--- a/src/api/types/nes.types.ts
+++ b/src/api/types/nes.types.ts
@@ -41,6 +41,7 @@ export interface InsightsEolScanComponentInfo {
   eolAt: Date | null;
   status: ComponentStatus;
   daysEol: number | null;
+  vulnCount: number;
 }
 
 export interface InsightsEolScanComponent {

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -1,7 +1,7 @@
-import { Command, Flags, ux } from '@oclif/core';
-import type { Table } from 'cli-table3';
 import fs from 'node:fs';
 import path from 'node:path';
+import { Command, Flags, ux } from '@oclif/core';
+import type { Table } from 'cli-table3';
 import { batchSubmitPurls } from '../../api/nes/nes.client.ts';
 import type { ScanResult } from '../../api/types/hd-cli.types.js';
 import type { ComponentStatus, InsightsEolScanComponent } from '../../api/types/nes.types.ts';

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -7,7 +7,7 @@ import type { ComponentStatus, InsightsEolScanComponent } from '../../api/types/
 import type { Sbom } from '../../service/eol/cdx.svc.ts';
 import { getErrorMessage, isErrnoException } from '../../service/error.svc.ts';
 import { extractPurls, parsePurlsFile } from '../../service/purls.svc.ts';
-import { createStatusDisplay, createTableForStatus } from '../../ui/eol.ui.ts';
+import { createStatusDisplay, createTableForStatus, groupComponentsByStatus } from '../../ui/eol.ui.ts';
 import { INDICATORS, STATUS_COLORS } from '../../ui/shared.ui.ts';
 import ScanSbom from './sbom.ts';
 
@@ -167,17 +167,14 @@ export default class ScanEol extends Command {
   }
 
   private displayResultsInTable(scan: ScanResult, all: boolean) {
-    const statuses: ComponentStatus[] = ['LTS', 'EOL'];
-
-    if (all) {
-      statuses.unshift('UNKNOWN', 'OK');
-    }
+    const grouped = groupComponentsByStatus(scan.components);
+    const statuses: ComponentStatus[] = all ? ['UNKNOWN', 'OK', 'LTS', 'EOL'] : ['LTS', 'EOL'];
 
     for (const status of statuses) {
-      const table = createTableForStatus(scan.components, status);
-
-      if (table.length > 0) {
-        this.displayTable(table, table.length, status);
+      const components = grouped[status];
+      if (components.length > 0) {
+        const table = createTableForStatus(grouped, status);
+        this.displayTable(table, components.length, status);
       }
     }
   }

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -1,7 +1,7 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { Command, Flags, ux } from '@oclif/core';
 import type { Table } from 'cli-table3';
+import fs from 'node:fs';
+import path from 'node:path';
 import { batchSubmitPurls } from '../../api/nes/nes.client.ts';
 import type { ScanResult } from '../../api/types/hd-cli.types.js';
 import type { ComponentStatus, InsightsEolScanComponent } from '../../api/types/nes.types.ts';

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -173,7 +173,7 @@ export default class ScanEol extends Command {
     if (all) {
       statuses.unshift('UNKNOWN', 'OK');
     }
-    
+
     for (const status of statuses) {
       const components = grouped[status];
       if (components.length > 0) {

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { Command, Flags, ux } from '@oclif/core';
-import type { Table } from 'cli-table3';
 import { batchSubmitPurls } from '../../api/nes/nes.client.ts';
 import type { ScanResult } from '../../api/types/hd-cli.types.js';
 import type { ComponentStatus, InsightsEolScanComponent } from '../../api/types/nes.types.ts';
@@ -183,9 +182,9 @@ export default class ScanEol extends Command {
     }
   }
 
-  private displayTable(table: Table, count: number, status: ComponentStatus): void {
+  private displayTable(table: string, count: number, status: ComponentStatus): void {
     this.log(ux.colorize(STATUS_COLORS[status], `${INDICATORS[status]} ${count} ${status} Component(s):`));
-    this.log(ux.colorize(STATUS_COLORS[status], table.toString()));
+    this.log(ux.colorize(STATUS_COLORS[status], table));
   }
 
   private displayNoComponentsMessage(all: boolean): void {

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -168,8 +168,12 @@ export default class ScanEol extends Command {
 
   private displayResultsInTable(scan: ScanResult, all: boolean) {
     const grouped = groupComponentsByStatus(scan.components);
-    const statuses: ComponentStatus[] = all ? ['UNKNOWN', 'OK', 'LTS', 'EOL'] : ['LTS', 'EOL'];
+    const statuses: ComponentStatus[] = ['LTS', 'EOL'];
 
+    if (all) {
+      statuses.unshift('UNKNOWN', 'OK');
+    }
+    
     for (const status of statuses) {
       const components = grouped[status];
       if (components.length > 0) {

--- a/src/service/eol/eol.svc.ts
+++ b/src/service/eol/eol.svc.ts
@@ -1,4 +1,3 @@
-import type { ScanInputOptions } from '../../api/types/hd-cli.types.ts';
 import { debugLogger } from '../../service/log.svc.ts';
 import { type Sbom, createBomFromDir } from './cdx.svc.ts';
 

--- a/src/service/nes/nes.svc.ts
+++ b/src/service/nes/nes.svc.ts
@@ -28,6 +28,7 @@ export const SbomScanner =
   async (purls: string[], options: ScanInputOptions): Promise<InsightsEolScanResult> => {
     const { type, page, totalPages, scanId } = options;
     const input: InsightsEolScanInput = { components: purls, type, page, totalPages, scanId };
+
     const res = await client.mutate<ScanResponse, { input: InsightsEolScanInput }>(M_SCAN.gql, { input });
 
     const scan = res.data?.insights?.scan?.eol;

--- a/src/ui/eol.ui.ts
+++ b/src/ui/eol.ui.ts
@@ -2,7 +2,11 @@ import { ux } from '@oclif/core';
 import Table from 'cli-table3';
 import { PackageURL } from 'packageurl-js';
 import type { ScanResultComponentsMap } from '../api/types/hd-cli.types.ts';
-import type { ComponentStatus, InsightsEolScanComponent } from '../api/types/nes.types.ts';
+import type {
+  ComponentStatus,
+  InsightsEolScanComponent,
+  InsightsEolScanComponentInfo,
+} from '../api/types/nes.types.ts';
 import { parseMomentToSimpleDate } from './date.ui.ts';
 import { INDICATORS, MAX_PURL_LENGTH, MAX_TABLE_COLUMN_WIDTH, STATUS_COLORS } from './shared.ui.ts';
 
@@ -36,17 +40,17 @@ function getDaysEolString(daysEol: number | null): string {
   return `${daysEol} days ago`;
 }
 
-function formatDetailedComponent(
-  purl: string,
-  eolAt: Date | null,
-  daysEol: number | null,
-  status: ComponentStatus,
-): string {
+function formatDetailedComponent(purl: string, info: InsightsEolScanComponentInfo): string {
+  const { status, eolAt, daysEol, vulnCount } = info;
   const simpleComponent = formatSimpleComponent(purl, status);
   const eolAtString = parseMomentToSimpleDate(eolAt);
   const daysEolString = getDaysEolString(daysEol);
 
-  const output = [`${simpleComponent}`, `    ⮑  EOL Date: ${eolAtString} (${daysEolString})`]
+  const output = [
+    `${simpleComponent}`,
+    `    ⮑  EOL Date: ${eolAtString} (${daysEolString})`,
+    `    ⮑  # of Vulns: ${vulnCount}`,
+  ]
     .filter(Boolean)
     .join('\n');
 
@@ -66,7 +70,7 @@ export function createStatusDisplay(
 
   // Single loop to separate and format components
   for (const [purl, component] of components.entries()) {
-    const { status, eolAt, daysEol } = component.info;
+    const { status } = component.info;
 
     if (all) {
       if (status === 'UNKNOWN' || status === 'OK') {
@@ -74,7 +78,7 @@ export function createStatusDisplay(
       }
     }
     if (status === 'LTS' || status === 'EOL') {
-      statusOutput[status].push(formatDetailedComponent(purl, eolAt, daysEol, status));
+      statusOutput[status].push(formatDetailedComponent(purl, component.info));
     }
   }
 

--- a/src/ui/eol.ui.ts
+++ b/src/ui/eol.ui.ts
@@ -85,22 +85,11 @@ export function createStatusDisplay(
   return statusOutput;
 }
 
-export function createTableForStatus(components: ScanResultComponentsMap, status: ComponentStatus) {
-  const data: Array<{
-    name: string;
-    version: string;
-    eol: string;
-    daysEol: number | null;
-    type: string;
-    vulnCount: number;
-  }> = [];
-
-  for (const component of components.values()) {
-    if (component.info.status !== status) continue;
-
-    const row = convertComponentToTableRow(component);
-    data.push(row);
-  }
+export function createTableForStatus(
+  grouped: Record<ComponentStatus, InsightsEolScanComponent[]>,
+  status: ComponentStatus,
+) {
+  const data = grouped[status].map((component) => convertComponentToTableRow(component));
 
   return makeTable({
     data,
@@ -127,4 +116,21 @@ export function convertComponentToTableRow(component: InsightsEolScanComponent) 
     type: purlParts.type,
     vulnCount: vulnCount,
   };
+}
+
+export function groupComponentsByStatus(
+  components: ScanResultComponentsMap,
+): Record<ComponentStatus, InsightsEolScanComponent[]> {
+  const grouped: Record<ComponentStatus, InsightsEolScanComponent[]> = {
+    UNKNOWN: [],
+    OK: [],
+    LTS: [],
+    EOL: [],
+  };
+
+  return Array.from(components.values()).reduce((acc, component) => {
+    const status = component.info.status;
+    acc[status].push(component);
+    return acc;
+  }, grouped);
 }

--- a/src/ui/eol.ui.ts
+++ b/src/ui/eol.ui.ts
@@ -128,9 +128,9 @@ export function groupComponentsByStatus(
     EOL: [],
   };
 
-  return Array.from(components.values()).reduce((acc, component) => {
-    const status = component.info.status;
-    acc[status].push(component);
-    return acc;
-  }, grouped);
+  for (const component of components.values()) {
+    grouped[component.info.status].push(component);
+  }
+
+  return grouped;
 }

--- a/src/ui/eol.ui.ts
+++ b/src/ui/eol.ui.ts
@@ -83,8 +83,8 @@ export function createStatusDisplay(
 
 export function createTableForStatus(components: ScanResultComponentsMap, status: ComponentStatus): Table.Table {
   const table = new Table({
-    head: ['NAME', 'VERSION', 'EOL', 'DAYS EOL', 'TYPE'],
-    colWidths: [MAX_TABLE_COLUMN_WIDTH, 10, 12, 10, 12],
+    head: ['NAME', 'VERSION', 'EOL', 'DAYS EOL', 'TYPE', '# OF VULNS'],
+    colWidths: [MAX_TABLE_COLUMN_WIDTH, 10, 12, 10, 12, 12],
     wordWrap: true,
     style: {
       'padding-left': 1,
@@ -105,7 +105,7 @@ export function createTableForStatus(components: ScanResultComponentsMap, status
 
 export function convertComponentToTableRow(component: InsightsEolScanComponent) {
   const purlParts = PackageURL.fromString(component.purl);
-  const { eolAt, daysEol } = component.info;
+  const { eolAt, daysEol, vulnCount } = component.info;
 
   return [
     { content: purlParts.name },
@@ -113,6 +113,6 @@ export function convertComponentToTableRow(component: InsightsEolScanComponent) 
     { content: parseMomentToSimpleDate(eolAt) },
     { content: daysEol },
     { content: purlParts.type },
-    // vulns: component.vulns.length, // TODO: add vulns to monorepo api
+    { content: vulnCount },
   ];
 }

--- a/test/ui/eol.ui.test.ts
+++ b/test/ui/eol.ui.test.ts
@@ -43,12 +43,13 @@ describe('EOL UI', () => {
       const result = convertComponentToTableRow(component);
 
       // Assert
-      assert.strictEqual(result.length, 5);
+      assert.strictEqual(result.length, 6);
       assert.strictEqual(result[0].content, 'very-long-package-name-that-exceeds-thirty-characters');
       assert.strictEqual(result[1].content, '1.0.0');
       assert.strictEqual(result[2].content, '2023-01-01');
       assert.strictEqual(result[3].content, 365);
       assert.strictEqual(result[4].content, 'npm');
+      assert.strictEqual(result[5].content, 0); // Default vulnCount
     });
 
     it('handles null values for eolAt and daysEol', () => {
@@ -59,12 +60,13 @@ describe('EOL UI', () => {
       const result = convertComponentToTableRow(component);
 
       // Assert
-      assert.strictEqual(result.length, 5);
+      assert.strictEqual(result.length, 6);
       assert.strictEqual(result[0].content, 'test');
       assert.strictEqual(result[1].content, '1.0.0');
       assert.strictEqual(result[2].content, '');
       assert.strictEqual(result[3].content, null);
       assert.strictEqual(result[4].content, 'npm');
+      assert.strictEqual(result[5].content, 0); // Default vulnCount
     });
   });
 
@@ -83,8 +85,8 @@ describe('EOL UI', () => {
       // Assert
       assert.strictEqual(table.length, 2);
       assert.strictEqual(table.length, 2); // Only data rows (excluding header)
-      assert.deepStrictEqual(table.options.head, ['NAME', 'VERSION', 'EOL', 'DAYS EOL', 'TYPE']);
-      assert.deepStrictEqual(table.options.colWidths, [30, 10, 12, 10, 12]);
+      assert.deepStrictEqual(table.options.head, ['NAME', 'VERSION', 'EOL', 'DAYS EOL', 'TYPE', '# OF VULNS']);
+      assert.deepStrictEqual(table.options.colWidths, [30, 10, 12, 10, 12, 12]);
     });
 
     it('returns empty table when no components match status', () => {

--- a/test/ui/eol.ui.test.ts
+++ b/test/ui/eol.ui.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { convertComponentToTableRow, createTableForStatus, truncateString } from '../../src/ui/eol.ui.ts';
+import {
+  convertComponentToTableRow,
+  createTableForStatus,
+  groupComponentsByStatus,
+  truncateString,
+} from '../../src/ui/eol.ui.ts';
 import { createMockComponent, createMockScan } from '../utils/mocks/scan-result-component.mock.ts';
 
 describe('EOL UI', () => {
@@ -76,9 +81,10 @@ describe('EOL UI', () => {
         createMockComponent('pkg:npm/test2@2.0.0', 'OK'),
         createMockComponent('pkg:npm/test3@3.0.0', 'EOL', new Date('2023-02-01'), 400),
       ]).components;
+      const grouped = groupComponentsByStatus(components);
 
       // Act
-      const table = createTableForStatus(components, 'EOL');
+      const table = createTableForStatus(grouped, 'EOL');
 
       // Assert
       assert.strictEqual(typeof table, 'string');
@@ -90,9 +96,10 @@ describe('EOL UI', () => {
     it('returns empty table when no components match status', () => {
       // Arrange
       const components = createMockScan([createMockComponent('pkg:npm/test1@1.0.0', 'OK')]).components;
+      const grouped = groupComponentsByStatus(components);
 
       // Act
-      const table = createTableForStatus(components, 'EOL');
+      const table = createTableForStatus(grouped, 'EOL');
 
       // Assert
       assert.strictEqual(typeof table, 'string');

--- a/test/ui/eol.ui.test.ts
+++ b/test/ui/eol.ui.test.ts
@@ -43,13 +43,12 @@ describe('EOL UI', () => {
       const result = convertComponentToTableRow(component);
 
       // Assert
-      assert.strictEqual(result.length, 6);
-      assert.strictEqual(result[0].content, 'very-long-package-name-that-exceeds-thirty-characters');
-      assert.strictEqual(result[1].content, '1.0.0');
-      assert.strictEqual(result[2].content, '2023-01-01');
-      assert.strictEqual(result[3].content, 365);
-      assert.strictEqual(result[4].content, 'npm');
-      assert.strictEqual(result[5].content, 0); // Default vulnCount
+      assert.strictEqual(result.name, 'very-long-package-name-that-exceeds-thirty-characters');
+      assert.strictEqual(result.version, '1.0.0');
+      assert.strictEqual(result.eol, '2023-01-01');
+      assert.strictEqual(result.daysEol, 365);
+      assert.strictEqual(result.type, 'npm');
+      assert.strictEqual(result.vulnCount, 0); // Default vulnCount
     });
 
     it('handles null values for eolAt and daysEol', () => {
@@ -60,13 +59,12 @@ describe('EOL UI', () => {
       const result = convertComponentToTableRow(component);
 
       // Assert
-      assert.strictEqual(result.length, 6);
-      assert.strictEqual(result[0].content, 'test');
-      assert.strictEqual(result[1].content, '1.0.0');
-      assert.strictEqual(result[2].content, '');
-      assert.strictEqual(result[3].content, null);
-      assert.strictEqual(result[4].content, 'npm');
-      assert.strictEqual(result[5].content, 0); // Default vulnCount
+      assert.strictEqual(result.name, 'test');
+      assert.strictEqual(result.version, '1.0.0');
+      assert.strictEqual(result.eol, '');
+      assert.strictEqual(result.daysEol, null);
+      assert.strictEqual(result.type, 'npm');
+      assert.strictEqual(result.vulnCount, 0); // Default vulnCount
     });
   });
 
@@ -83,10 +81,10 @@ describe('EOL UI', () => {
       const table = createTableForStatus(components, 'EOL');
 
       // Assert
-      assert.strictEqual(table.length, 2);
-      assert.strictEqual(table.length, 2); // Only data rows (excluding header)
-      assert.deepStrictEqual(table.options.head, ['NAME', 'VERSION', 'EOL', 'DAYS EOL', 'TYPE', '# OF VULNS']);
-      assert.deepStrictEqual(table.options.colWidths, [30, 10, 12, 10, 12, 12]);
+      assert.strictEqual(typeof table, 'string');
+      // Check that the table contains the expected data, ignoring exact formatting
+      assert.match(table, /test1.*1.0.0.*2023-01-01.*365.*npm.*0/);
+      assert.match(table, /test3.*3.0.0.*2023-02-01.*400.*npm.*0/);
     });
 
     it('returns empty table when no components match status', () => {
@@ -97,7 +95,9 @@ describe('EOL UI', () => {
       const table = createTableForStatus(components, 'EOL');
 
       // Assert
-      assert.strictEqual(table.length, 0); // No data rows
+      assert.strictEqual(typeof table, 'string');
+      // The table should be empty except for headers
+      assert.doesNotMatch(table, /test1/);
     });
   });
 });

--- a/test/utils/mocks/scan-result-component.mock.ts
+++ b/test/utils/mocks/scan-result-component.mock.ts
@@ -6,6 +6,7 @@ export const createMockComponent = (
   status: 'OK' | 'EOL' | 'LTS' = 'OK',
   eolAt: Date | null = null,
   daysEol: number | null = null,
+  vulnCount = 0,
 ): InsightsEolScanComponent => ({
   purl,
   info: {
@@ -14,6 +15,7 @@ export const createMockComponent = (
     isUnsafe: false,
     status,
     daysEol,
+    vulnCount,
   },
 });
 


### PR DESCRIPTION
This PR does two things:
1. Replace cli-table3 with pre-existing dependency (@oclif/table)
2. Add vulnCount to the table output.

We are waiting on a backend deployment before we actually have vulnCount numbers. A PR is open with that update. Until then, the vulnCount property in the gql query must be commented out.

As explained in the commit messages, I noticed that we already have a dependency on the @oclif/table package so I decided to reduce our dependencies and just use that instead of cli-table3.