### PR TITLE
chore: improve error handling for purl files

### DIFF
--- a/src/service/purls.svc.ts
+++ b/src/service/purls.svc.ts
@@ -38,7 +38,13 @@ export async function extractPurls(sbom: Sbom): Promise<string[]> {
  * or a text file with one purl per line.
  */
 export function parsePurlsFile(purlsFileString: string): string[] {
+  // Handle empty string
+  if (!purlsFileString.trim()) {
+    return [];
+  }
+
   try {
+    // Try parsing as JSON first
     const parsed = JSON.parse(purlsFileString);
 
     if (parsed && Array.isArray(parsed.purls)) {
@@ -49,11 +55,18 @@ export function parsePurlsFile(purlsFileString: string): string[] {
       return parsed;
     }
   } catch {
+    // If not JSON, try parsing as text file
     const lines = purlsFileString
       .split('\n')
       .map((line) => line.trim())
       .filter((line) => line.length > 0 && line.startsWith('pkg:'));
 
+    // Handle single purl case (no newlines)
+    if (lines.length === 0 && purlsFileString.trim().startsWith('pkg:')) {
+      return [purlsFileString.trim()];
+    }
+
+    // Return any valid purls found
     if (lines.length > 0) {
       return lines;
     }

--- a/test/service/purls.svc.test.ts
+++ b/test/service/purls.svc.test.ts
@@ -105,10 +105,14 @@ pkg:npm/typescript@5.0.0`;
       });
     });
 
-    it('should throw error for empty file', () => {
-      assert.throws(() => parsePurlsFile(''), {
-        message: 'Invalid purls file: must be either JSON with purls array or text file with one purl per line',
-      });
+    it('should return empty array for empty file', () => {
+      const result = parsePurlsFile('');
+      assert.deepStrictEqual(result, []);
+    });
+
+    it('should return empty array for whitespace-only file', () => {
+      const result = parsePurlsFile('  \n  \t  ');
+      assert.deepStrictEqual(result, []);
     });
 
     it('should throw error for file with no valid purls', () => {


### PR DESCRIPTION
I came across an error when running the tool and zero purls were generated. Instead of throwing an error in this case, we should handle it gracefully.

![Screenshot 2025-04-24 at 4 55 18 PM](https://github.com/user-attachments/assets/f1ad2cdc-b83c-4a56-9e87-9d84193b514e)


