### PR TITLE
feat: run `scan eol -t` by default

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -13,7 +13,6 @@ process.env.GRAPHQL_HOST = 'https://api.dev.nes.herodevs.com';
 
 // If no command is provided, default to scan:eol -t
 // See https://github.com/oclif/oclif/issues/277#issuecomment-657352674 for more info
-// There is no canonical way to do this, so we're using a hacky solution
 if (process.argv.length === 2) {
   process.argv[2] = 'scan:eol';
   process.argv[3] = '-t';

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -11,4 +11,12 @@ process.env.GRAPHQL_HOST = 'https://api.dev.nes.herodevs.com';
 // Prod
 // process.env.GRAPHQL_HOST = 'https://api.nes.herodevs.com';
 
+// If no command is provided, default to scan:eol -t
+// See https://github.com/oclif/oclif/issues/277#issuecomment-657352674 for more info
+// There is no canonical way to do this, so we're using a hacky solution
+if (process.argv.length === 2) {
+  process.argv[2] = 'scan:eol';
+  process.argv[3] = '-t';
+}
+
 await execute({ development: true, dir: import.meta.url });

--- a/bin/run.js
+++ b/bin/run.js
@@ -4,7 +4,6 @@ import { execute } from '@oclif/core';
 
 // If no command is provided, default to scan:eol -t
 // See https://github.com/oclif/oclif/issues/277#issuecomment-657352674 for more info
-// There is no canonical way to do this, so we're using a hacky solution
 if (process.argv.length === 2) {
   process.argv[2] = 'scan:eol';
   process.argv[3] = '-t';

--- a/bin/run.js
+++ b/bin/run.js
@@ -2,4 +2,12 @@
 
 import { execute } from '@oclif/core';
 
+// If no command is provided, default to scan:eol -t
+// See https://github.com/oclif/oclif/issues/277#issuecomment-657352674 for more info
+// There is no canonical way to do this, so we're using a hacky solution
+if (process.argv.length === 2) {
+  process.argv[2] = 'scan:eol';
+  process.argv[3] = '-t';
+}
+
 await execute({ dir: import.meta.url });

--- a/e2e/scan/eol.test.ts
+++ b/e2e/scan/eol.test.ts
@@ -1,4 +1,3 @@
-import { runCommand } from '@oclif/test';
 import { doesNotThrow } from 'node:assert';
 import { doesNotMatch, match, strictEqual } from 'node:assert/strict';
 import { exec } from 'node:child_process';
@@ -8,6 +7,7 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { runCommand } from '@oclif/test';
 
 const execAsync = promisify(exec);
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
       "@oclif/plugin-update"
     ],
     "hooks": {
-      "init": "./dist/hooks/npm-update-notifier",
+      "init": "./dist/hooks/npm-update-notifier.js",
       "prerun": "./dist/hooks/prerun.js"
     },
     "topicSeparator": " ",


### PR DESCRIPTION
When the user provides no arguments to the cli, by default it should run `scan eol-t`.

@marco-ippolito do not merge this even if it has two approvals. This is pointed to the release branch. I'm waiting on the release branch to be approved so I can merge that branch and deploy the tag.