### PR TITLE
feat: accept scan eol flags by default

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-import { execute } from '@oclif/core';
-
 // Localhost
 // process.env.GRAPHQL_HOST = 'http://localhost:3000';
 
@@ -11,11 +9,6 @@ process.env.GRAPHQL_HOST = 'https://api.dev.nes.herodevs.com';
 // Prod
 // process.env.GRAPHQL_HOST = 'https://api.nes.herodevs.com';
 
-// If no command is provided, default to scan:eol -t
-// See https://github.com/oclif/oclif/issues/277#issuecomment-657352674 for more info
-if (process.argv.length === 2) {
-  process.argv[2] = 'scan:eol';
-  process.argv[3] = '-t';
-}
+import main from './main.js';
 
-await execute({ development: true, dir: import.meta.url });
+main(false).catch(console.error);

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -11,4 +11,8 @@ process.env.GRAPHQL_HOST = 'https://api.dev.nes.herodevs.com';
 
 import main from './main.js';
 
-main(false).catch(console.error);
+try {
+  await main(false);
+} catch (error) {
+  process.exit(1);
+}

--- a/bin/main.js
+++ b/bin/main.js
@@ -20,10 +20,14 @@ async function main(isProduction = false) {
     }
   }
 
-  await execute({
-    development: !isProduction,
-    dir: new URL('./dev.js', import.meta.url),
-  });
+  try {
+    await execute({
+      development: !isProduction,
+      dir: new URL('./dev.js', import.meta.url),
+    });
+  } catch (error) {
+    process.exit(1);
+  }
 }
 
 export default main;

--- a/bin/main.js
+++ b/bin/main.js
@@ -11,7 +11,7 @@ async function main(isProduction = false) {
     const isFlag = firstArg.startsWith('-');
 
     // If it's a flag or not a valid command, insert scan:eol
-    if (isFlag || (!firstArg.includes(':') && process.argv.length === 3)) {
+    if (isFlag && !['--help', '-h'].includes(firstArg)) {
       process.argv.splice(2, 0, 'scan:eol');
       // Add -t flag if no other flags are present
       if (!process.argv.some((arg) => arg.startsWith('-'))) {

--- a/bin/main.js
+++ b/bin/main.js
@@ -1,23 +1,20 @@
+import { parseArgs } from 'node:util';
 import { execute } from '@oclif/core';
 
 async function main(isProduction = false) {
-  // If no command is provided, default to scan:eol -t
-  // See https://github.com/oclif/oclif/issues/277#issuecomment-657352674 for more info
-  if (process.argv.length === 2) {
-    process.argv[2] = 'scan:eol';
-    process.argv[3] = '-t';
-  } else if (process.argv.length > 2) {
-    const firstArg = process.argv[2];
-    const isFlag = firstArg.startsWith('-');
+  const { positionals } = parseArgs({
+    args: process.argv.slice(2),
+    allowPositionals: true,
+    strict: false, // Don't validate flags
+  });
 
-    // If it's a flag or not a valid command, insert scan:eol
-    if (isFlag && !['--help', '-h'].includes(firstArg)) {
-      process.argv.splice(2, 0, 'scan:eol');
-      // Add -t flag if no other flags are present
-      if (!process.argv.some((arg) => arg.startsWith('-'))) {
-        process.argv.splice(3, 0, '-t');
-      }
-    }
+  // If no arguments at all, default to scan:eol -t
+  if (positionals.length === 0) {
+    process.argv.splice(2, 0, 'scan:eol', '-t');
+  }
+  // If only flags are provided, set scan:eol as the command for those flags
+  else if (positionals.length === 1 && positionals[0].startsWith('-')) {
+    process.argv.splice(2, 0, 'scan:eol');
   }
 
   try {

--- a/bin/main.js
+++ b/bin/main.js
@@ -3,7 +3,6 @@ import { execute } from '@oclif/core';
 
 async function main(isProduction = false) {
   const { positionals } = parseArgs({
-    args: process.argv.slice(2),
     allowPositionals: true,
     strict: false, // Don't validate flags
   });

--- a/bin/main.js
+++ b/bin/main.js
@@ -1,0 +1,29 @@
+import { execute } from '@oclif/core';
+
+async function main(isProduction = false) {
+  // If no command is provided, default to scan:eol -t
+  // See https://github.com/oclif/oclif/issues/277#issuecomment-657352674 for more info
+  if (process.argv.length === 2) {
+    process.argv[2] = 'scan:eol';
+    process.argv[3] = '-t';
+  } else if (process.argv.length > 2) {
+    const firstArg = process.argv[2];
+    const isFlag = firstArg.startsWith('-');
+
+    // If it's a flag or not a valid command, insert scan:eol
+    if (isFlag || (!firstArg.includes(':') && process.argv.length === 3)) {
+      process.argv.splice(2, 0, 'scan:eol');
+      // Add -t flag if no other flags are present
+      if (!process.argv.some((arg) => arg.startsWith('-'))) {
+        process.argv.splice(3, 0, '-t');
+      }
+    }
+  }
+
+  await execute({
+    development: !isProduction,
+    dir: new URL('./dev.js', import.meta.url),
+  });
+}
+
+export default main;

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,12 +1,5 @@
 #!/usr/bin/env node
 
-import { execute } from '@oclif/core';
+import main from './main.js';
 
-// If no command is provided, default to scan:eol -t
-// See https://github.com/oclif/oclif/issues/277#issuecomment-657352674 for more info
-if (process.argv.length === 2) {
-  process.argv[2] = 'scan:eol';
-  process.argv[3] = '-t';
-}
-
-await execute({ dir: import.meta.url });
+await main();

--- a/bin/run.js
+++ b/bin/run.js
@@ -2,4 +2,8 @@
 
 import main from './main.js';
 
-await main();
+try {
+  await main(true);
+} catch (error) {
+  process.exit(1);
+}

--- a/e2e/scan/eol.test.ts
+++ b/e2e/scan/eol.test.ts
@@ -55,6 +55,17 @@ describe('default arguments', () => {
     doesNotMatch(stdout, /Here are the results of the scan:/, 'Should not show results header');
     doesNotThrow(() => JSON.parse(stdout), 'Output should be valid JSON');
   });
+
+  it('shows help when --help is passed in', async () => {
+    const { stdout } = await execAsync('node bin/run.js --help', {
+      env: { ...process.env, GRAPHQL_HOST },
+    });
+
+    // Verify help output
+    match(stdout, /USAGE/, 'Should show usage section');
+    match(stdout, /TOPICS/, 'Should show topics section');
+    match(stdout, /COMMANDS/, 'Should show commands section');
+  });
 });
 describe('scan:eol e2e', () => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/e2e/scan/eol.test.ts
+++ b/e2e/scan/eol.test.ts
@@ -56,8 +56,19 @@ describe('default arguments', () => {
     doesNotThrow(() => JSON.parse(stdout), 'Output should be valid JSON');
   });
 
-  it('shows help when --help is passed in', async () => {
+  it('shows help for scan:eol when --help is passed in', async () => {
     const { stdout } = await execAsync('node bin/run.js --help', {
+      env: { ...process.env, GRAPHQL_HOST },
+    });
+
+    // Verify help output
+    match(stdout, /USAGE/, 'Should show usage section');
+    match(stdout, /FLAGS/, 'Should show flags section');
+    match(stdout, /EXAMPLES/, 'Should show examples section');
+  });
+
+  it('shows global help when help is passed in', async () => {
+    const { stdout } = await execAsync('node bin/run.js help', {
       env: { ...process.env, GRAPHQL_HOST },
     });
 


### PR DESCRIPTION
Previously, the command `npx @herodevs/cli@beta --json` would fail.

With this change, users pass in flags and apply them to the `scan eol` command by default.