### PR TITLE
chore: switch to throw error instead of this.error

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -22,7 +22,10 @@ async function main(isProduction = false) {
       dir: new URL('./dev.js', import.meta.url),
     });
   } catch (error) {
-    process.exit(1);
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(String(error));
   }
 }
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -39,8 +39,8 @@ export class ApolloClient implements ApolloHelper {
         mutation,
         variables,
       });
-    } catch (error: unknown) {
-      throw new Error('GraphQL mutation failed', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('GraphQL mutation failed', { cause });
     }
   }
 
@@ -50,8 +50,8 @@ export class ApolloClient implements ApolloHelper {
         query,
         variables,
       });
-    } catch (error) {
-      throw new Error('GraphQL query failed', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('GraphQL query failed', { cause });
     }
   }
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,4 @@
 import * as apollo from '@apollo/client/core/index.js';
-import { ApolloError } from '../service/error.svc.ts';
 
 export interface ApolloHelper {
   mutate<T, V extends apollo.OperationVariables>(
@@ -41,7 +40,7 @@ export class ApolloClient implements ApolloHelper {
         variables,
       });
     } catch (error: unknown) {
-      throw new ApolloError('GraphQL mutation failed', error);
+      throw new Error('GraphQL mutation failed', { cause: error });
     }
   }
 
@@ -52,7 +51,7 @@ export class ApolloClient implements ApolloHelper {
         variables,
       });
     } catch (error) {
-      throw new ApolloError('GraphQL query failed', error);
+      throw new Error('GraphQL query failed', { cause: error });
     }
   }
 }

--- a/src/api/nes/nes.client.ts
+++ b/src/api/nes/nes.client.ts
@@ -73,9 +73,9 @@ export const batchSubmitPurls = async (
 
     const results = await processBatches(batches, options);
     return handleBatchResults(results);
-  } catch (error) {
-    debugLogger('Fatal error in batchSubmitPurls: %s', error);
-    throw new Error('Failed to process purls', { cause: error });
+  } catch (cause: unknown) {
+    debugLogger('Fatal error in batchSubmitPurls: %s', cause);
+    throw new Error('Failed to process purls', { cause });
   }
 };
 

--- a/src/api/nes/nes.client.ts
+++ b/src/api/nes/nes.client.ts
@@ -75,7 +75,7 @@ export const batchSubmitPurls = async (
     return handleBatchResults(results);
   } catch (error) {
     debugLogger('Fatal error in batchSubmitPurls: %s', error);
-    throw new Error(`Failed to process purls: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error('Failed to process purls', { cause: error });
   }
 };
 

--- a/src/commands/report/committers.ts
+++ b/src/commands/report/committers.ts
@@ -152,7 +152,9 @@ export default class Committers extends Command {
     if (logProcess.error) {
       if (isErrnoException(logProcess.error)) {
         if (logProcess.error.code === 'ENOENT') {
-          throw new Error('Git command not found. Please ensure git is installed and available in your PATH.');
+          throw new Error('Git command not found. Please ensure git is installed and available in your PATH.', {
+            cause: logProcess.error,
+          });
         }
         throw new Error('Git command failed', { cause: logProcess.error });
       }

--- a/src/commands/report/committers.ts
+++ b/src/commands/report/committers.ts
@@ -63,8 +63,8 @@ export default class Committers extends Command {
           try {
             fs.writeFileSync(path.resolve('eol.committers.json'), JSON.stringify(reportData, null, 2));
             this.log('Report written to json');
-          } catch (error) {
-            throw new Error('Failed to save JSON report', { cause: error });
+          } catch (cause: unknown) {
+            throw new Error('Failed to save JSON report', { cause });
           }
         }
         return reportData;
@@ -79,8 +79,8 @@ export default class Committers extends Command {
           try {
             fs.writeFileSync(path.resolve('eol.committers.csv'), csvOutput);
             this.log('Report written to csv');
-          } catch (error) {
-            throw new Error('Failed to save CSV report', { cause: error });
+          } catch (cause: unknown) {
+            throw new Error('Failed to save CSV report', { cause });
           }
         } else {
           this.log(textOutput);
@@ -92,15 +92,15 @@ export default class Committers extends Command {
         try {
           fs.writeFileSync(path.resolve('eol.committers.txt'), textOutput);
           this.log('Report written to txt');
-        } catch (error) {
-          throw new Error('Failed to save txt report', { cause: error });
+        } catch (cause: unknown) {
+          throw new Error('Failed to save txt report', { cause });
         }
       } else {
         this.log(textOutput);
       }
       return textOutput;
-    } catch (error) {
-      throw new Error('Failed to generate report', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('Failed to generate report', { cause });
     }
   }
 

--- a/src/commands/report/committers.ts
+++ b/src/commands/report/committers.ts
@@ -12,7 +12,7 @@ import {
   groupCommitsByMonth,
   parseGitLogOutput,
 } from '../../service/committers.svc.ts';
-import { getErrorMessage, isErrnoException } from '../../service/error.svc.ts';
+import { isErrnoException } from '../../service/error.svc.ts';
 
 export default class Committers extends Command {
   static override description = 'Generate report of committers to a git repository';
@@ -64,7 +64,7 @@ export default class Committers extends Command {
             fs.writeFileSync(path.resolve('eol.committers.json'), JSON.stringify(reportData, null, 2));
             this.log('Report written to json');
           } catch (error) {
-            this.error(`Failed to save JSON report: ${getErrorMessage(error)}`);
+            throw new Error('Failed to save JSON report', { cause: error });
           }
         }
         return reportData;
@@ -80,7 +80,7 @@ export default class Committers extends Command {
             fs.writeFileSync(path.resolve('eol.committers.csv'), csvOutput);
             this.log('Report written to csv');
           } catch (error) {
-            this.error(`Failed to save CSV report: ${getErrorMessage(error)}`);
+            throw new Error('Failed to save CSV report', { cause: error });
           }
         } else {
           this.log(textOutput);
@@ -93,14 +93,14 @@ export default class Committers extends Command {
           fs.writeFileSync(path.resolve('eol.committers.txt'), textOutput);
           this.log('Report written to txt');
         } catch (error) {
-          this.error(`Failed to save txt report: ${getErrorMessage(error)}`);
+          throw new Error('Failed to save txt report', { cause: error });
         }
       } else {
         this.log(textOutput);
       }
       return textOutput;
     } catch (error) {
-      this.error(`Failed to generate report: ${getErrorMessage(error)}`);
+      throw new Error('Failed to generate report', { cause: error });
     }
   }
 
@@ -152,15 +152,15 @@ export default class Committers extends Command {
     if (logProcess.error) {
       if (isErrnoException(logProcess.error)) {
         if (logProcess.error.code === 'ENOENT') {
-          this.error('Git command not found. Please ensure git is installed and available in your PATH.');
+          throw new Error('Git command not found. Please ensure git is installed and available in your PATH.');
         }
-        this.error(`Git command failed: ${getErrorMessage(logProcess.error)}`);
+        throw new Error('Git command failed', { cause: logProcess.error });
       }
-      this.error(`Git command failed: ${getErrorMessage(logProcess.error)}`);
+      throw new Error('Git command failed', { cause: logProcess.error });
     }
 
     if (logProcess.status !== 0) {
-      this.error(`Git command failed with status ${logProcess.status}: ${logProcess.stderr}`);
+      throw new Error(`Git command failed with status ${logProcess.status}`, { cause: logProcess.stderr });
     }
 
     if (!logProcess.stdout) {

--- a/src/commands/report/purls.ts
+++ b/src/commands/report/purls.ts
@@ -66,11 +66,11 @@ export default class ReportPurls extends Command {
           if (isErrnoException(cause)) {
             switch (cause.code) {
               case 'EACCES':
-                throw new Error('Permission denied: Cannot write to output file');
+                throw new Error('Permission denied: Cannot write to output file', { cause });
               case 'ENOSPC':
-                throw new Error('No space left on device');
+                throw new Error('No space left on device', { cause });
               case 'EISDIR':
-                throw new Error('Cannot write to output file: Is a directory');
+                throw new Error('Cannot write to output file: Is a directory', { cause });
               default:
                 throw new Error('Failed to save purls', { cause });
             }

--- a/src/commands/report/purls.ts
+++ b/src/commands/report/purls.ts
@@ -62,9 +62,9 @@ export default class ReportPurls extends Command {
           fs.writeFileSync(outputPath, purlOutput);
 
           this.log('Purls saved to %s', outputPath);
-        } catch (error: unknown) {
-          if (isErrnoException(error)) {
-            switch (error.code) {
+        } catch (cause: unknown) {
+          if (isErrnoException(cause)) {
+            switch (cause.code) {
               case 'EACCES':
                 throw new Error('Permission denied: Cannot write to output file');
               case 'ENOSPC':
@@ -72,17 +72,17 @@ export default class ReportPurls extends Command {
               case 'EISDIR':
                 throw new Error('Cannot write to output file: Is a directory');
               default:
-                throw new Error('Failed to save purls', { cause: error });
+                throw new Error('Failed to save purls', { cause });
             }
           }
-          throw new Error('Failed to save purls', { cause: error });
+          throw new Error('Failed to save purls', { cause });
         }
       }
 
       // Return wrapped object with metadata
       return { purls };
-    } catch (error) {
-      throw new Error('Failed to generate PURLs', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('Failed to generate PURLs', { cause });
     }
   }
 }

--- a/src/commands/report/purls.ts
+++ b/src/commands/report/purls.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Command, Flags, ux } from '@oclif/core';
 
-import { getErrorMessage, isErrnoException } from '../../service/error.svc.ts';
+import { isErrnoException } from '../../service/error.svc.ts';
 import { extractPurls, getPurlOutput } from '../../service/purls.svc.ts';
 import ScanSbom from '../scan/sbom.ts';
 
@@ -66,26 +66,23 @@ export default class ReportPurls extends Command {
           if (isErrnoException(error)) {
             switch (error.code) {
               case 'EACCES':
-                this.error('Permission denied: Cannot write to output file');
-                break;
+                throw new Error('Permission denied: Cannot write to output file');
               case 'ENOSPC':
-                this.error('No space left on device');
-                break;
+                throw new Error('No space left on device');
               case 'EISDIR':
-                this.error('Cannot write to output file: Is a directory');
-                break;
+                throw new Error('Cannot write to output file: Is a directory');
               default:
-                this.error(`Failed to save purls: ${getErrorMessage(error)}`);
+                throw new Error('Failed to save purls', { cause: error });
             }
           }
-          this.error(`Failed to save purls: ${getErrorMessage(error)}`);
+          throw new Error('Failed to save purls', { cause: error });
         }
       }
 
       // Return wrapped object with metadata
       return { purls };
     } catch (error) {
-      this.error(`Failed to generate PURLs: ${getErrorMessage(error)}`);
+      throw new Error('Failed to generate PURLs', { cause: error });
     }
   }
 }

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -136,9 +136,9 @@ export default class ScanEol extends Command {
       }
       switch (cause.code) {
         case 'EACCES':
-          throw new Error('Permission denied. Unable to save report to eol.report.json');
+          throw new Error('Permission denied. Unable to save report to eol.report.json', { cause });
         case 'ENOSPC':
-          throw new Error('No space left on device. Unable to save report to eol.report.json');
+          throw new Error('No space left on device. Unable to save report to eol.report.json', { cause });
         default:
           throw new Error('Failed to save report', { cause });
       }

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -90,8 +90,8 @@ export default class ScanEol extends Command {
     try {
       const purlsFileString = fs.readFileSync(filePath, 'utf8');
       return parsePurlsFile(purlsFileString);
-    } catch (error) {
-      throw new Error('Failed to read purls file', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('Failed to read purls file', { cause });
     }
   }
 
@@ -100,14 +100,14 @@ export default class ScanEol extends Command {
     let purls: string[];
 
     try {
-      purls = await extractPurls(sbom);
-    } catch (error) {
-      throw new Error('Failed to extract purls from sbom', { cause: error });
+      purls = extractPurls(sbom);
+    } catch (cause: unknown) {
+      throw new Error('Failed to extract purls from sbom', { cause });
     }
     try {
       scan = await batchSubmitPurls(purls);
-    } catch (error) {
-      throw new Error('Failed to submit scan to NES from sbom', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('Failed to submit scan to NES from sbom', { cause });
     }
 
     if (scan.components.size === 0) {
@@ -130,17 +130,17 @@ export default class ScanEol extends Command {
     try {
       fs.writeFileSync(reportPath, JSON.stringify({ components }, null, 2));
       this.log('Report saved to eol.report.json');
-    } catch (error) {
-      if (!isErrnoException(error)) {
-        throw new Error('Failed to save report', { cause: error });
+    } catch (cause: unknown) {
+      if (!isErrnoException(cause)) {
+        throw new Error('Failed to save report', { cause });
       }
-      switch (error.code) {
+      switch (cause.code) {
         case 'EACCES':
           throw new Error('Permission denied. Unable to save report to eol.report.json');
         case 'ENOSPC':
           throw new Error('No space left on device. Unable to save report to eol.report.json');
         default:
-          throw new Error('Failed to save report', { cause: error });
+          throw new Error('Failed to save report', { cause });
       }
     }
   }

--- a/src/commands/scan/sbom.ts
+++ b/src/commands/scan/sbom.ts
@@ -106,8 +106,8 @@ export default class ScanSbom extends Command {
         throw new Error(`SBOM failed to generate: ${dir}`);
       }
       return sbom;
-    } catch (error) {
-      throw new Error('Failed to scan directory', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('Failed to scan directory', { cause });
     }
   }
 
@@ -128,8 +128,8 @@ export default class ScanSbom extends Command {
       });
 
       workerProcess.unref();
-    } catch (error) {
-      throw new Error('Failed to start background scan', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('Failed to start background scan', { cause });
     }
   }
 
@@ -149,8 +149,8 @@ export default class ScanSbom extends Command {
       const sbom = JSON.parse(fileContent) as Sbom;
       validateIsCycloneDxSbom(sbom);
       return sbom;
-    } catch (error) {
-      throw new Error('Failed to read SBOM file', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('Failed to read SBOM file', { cause });
     }
   }
 
@@ -161,8 +161,8 @@ export default class ScanSbom extends Command {
       if (!this.jsonEnabled()) {
         this.log(`SBOM saved to ${outputPath}`);
       }
-    } catch (error) {
-      throw new Error('Failed to save SBOM', { cause: error });
+    } catch (cause: unknown) {
+      throw new Error('Failed to save SBOM', { cause });
     }
   }
 }

--- a/src/service/error.svc.ts
+++ b/src/service/error.svc.ts
@@ -5,28 +5,3 @@ export const isError = (error: unknown): error is Error => {
 export const isErrnoException = (error: unknown): error is NodeJS.ErrnoException => {
   return isError(error) && 'code' in error;
 };
-
-export const isApolloError = (error: unknown): error is ApolloError => {
-  return error instanceof ApolloError;
-};
-
-export const getErrorMessage = (error: unknown): string => {
-  if (isError(error)) {
-    return error.message;
-  }
-  return 'Unknown error';
-};
-
-export class ApolloError extends Error {
-  public readonly originalError?: unknown;
-
-  constructor(message: string, original?: unknown) {
-    if (isError(original)) {
-      super(`${message}: ${original.message}`);
-    } else {
-      super(`${message}: ${String(original)}`);
-    }
-    this.name = 'ApolloError';
-    this.originalError = original;
-  }
-}

--- a/src/service/nes/nes.svc.ts
+++ b/src/service/nes/nes.svc.ts
@@ -42,7 +42,7 @@ export const SbomScanner =
       debugLogger('failed scan %o', scan || {});
       debugLogger('scan failed');
 
-      throw new Error('Failed to provide scan: ');
+      throw new Error(`Scan failed: ${scan?.message}`);
     }
 
     return scan;

--- a/src/service/nes/nes.svc.ts
+++ b/src/service/nes/nes.svc.ts
@@ -27,7 +27,13 @@ export const SbomScanner =
   (client: NesApolloClient) =>
   async (purls: string[], options: ScanInputOptions): Promise<InsightsEolScanResult> => {
     const { type, page, totalPages, scanId } = options;
-    const input: InsightsEolScanInput = { components: purls, type, page, totalPages, scanId };
+    const input: InsightsEolScanInput = {
+      components: purls,
+      type,
+      page,
+      totalPages,
+      scanId,
+    };
 
     const res = await client.mutate<ScanResponse, { input: InsightsEolScanInput }>(M_SCAN.gql, { input });
 

--- a/src/ui/date.ui.ts
+++ b/src/ui/date.ui.ts
@@ -8,7 +8,7 @@ export function parseMomentToSimpleDate(momentDate: string | Date | number | nul
       throw new Error('Invalid date');
     }
     return dateObj.toISOString().split('T')[0];
-  } catch {
-    throw new Error('Invalid date');
+  } catch (cause: unknown) {
+    throw new Error('Invalid date', { cause });
   }
 }


### PR DESCRIPTION
Previously, we had two separate mechanisms for handling errors:
1. Invoking `this.error` from components; 
2. Throwing an error from a service

Invoking `this.error` is conventional in oclif, but this kind of error handling masks the underlying behavior and throws off our linter.

This PR consolidates our error handling to use the basic `Error` type and take advantage of the 'cause' Node api.[1]

[1]https://nodejs.org/api/errors.html#errorcause