### PR TITLE
EOL Report Permalink

### DIFF
--- a/src/api/queries/nes/sbom.ts
+++ b/src/api/queries/nes/sbom.ts
@@ -20,6 +20,7 @@ export const M_SCAN = {
             diagnostics
             message
             scanId
+            permalink
             success
             warnings {
               purl


### PR DESCRIPTION
Adds support to get the URL permalink from the service itself. 

@edezekiel we'll need to thread the needle and expose said permalink in the right spot (and maybe have a sensible fallback?)

# Dependencies 
- https://github.com/neverendingsupport/monorepo/pull/739