### PR TITLE
fix: ensure e2e tests don't run against prod

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export GRAPHQL_HOST='https://api.nes.herodevs.com';
+export EOL_REPORT_URL='https://eol-report-card.apps.herodevs.com/reports';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{matrix.node}}.x
+        env:
+          GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
+          EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,15 @@ jobs:
           - windows-latest
     name: "${{matrix.platform}} w/ Node.js ${{matrix.node}}.x"
     runs-on: ${{matrix.platform}}
+    env:
+      GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
+      EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: "Use Node.js ${{matrix.node}}.x"
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{matrix.node}}.x
-        env:
-          GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
-          EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -37,6 +37,9 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
+        env:
+          GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
+          EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -32,14 +32,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: check-version
+    env:
+      GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
+      EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
-        env:
-          GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
-          EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -46,14 +46,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: check-version
+    env:
+      GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
+      EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
-        env:
-          GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
-          EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -51,6 +51,9 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
+        env:
+          GRAPHQL_HOST: ${{ secrets.GRAPHQL_HOST }}
+          EOL_REPORT_URL: ${{ secrets.EOL_REPORT_URL }}
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn.lock
 pnpm-lock.yaml
 **/packages/cli-*/bin/
 **/tsconfig.tsbuildinfo
+.envrc

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-process.env.GRAPHQL_HOST = 'https://api.dev.nes.herodevs.com';
-process.env.EOL_REPORT_URL = 'https://eol-report-card.stage.apps.herodevs.io/reports';
-
 import main from './main.js';
 
 try {

--- a/e2e/scan/eol.test.ts
+++ b/e2e/scan/eol.test.ts
@@ -153,7 +153,7 @@ describe('scan:eol e2e', () => {
     unlinkSync(reportPath);
   });
 
-  it('scans extra-large.purls.json for EOL components', async () => {
+  it.skip('scans extra-large.purls.json for EOL components', async () => {
     const cmd = `scan:eol --purls ${extraLargePurlsPath}`;
     const { stdout } = await run(cmd);
 

--- a/src/api/nes/nes.client.ts
+++ b/src/api/nes/nes.client.ts
@@ -50,6 +50,7 @@ function submitScan(purls: string[], options: ScanInputOptions): Promise<Insight
   const host = config.graphqlHost;
   const path = config.graphqlPath;
   const url = host + path;
+  debugLogger('Submitting scan to %s', url);
   const client = new NesApolloClient(url);
   return client.scan.purls(purls, options);
 }


### PR DESCRIPTION
Previously, the e2e tests were being run against prod. This was not the intention. Process env variables were set in multiple places:
- bin/run.js
- bin/dev.js
- eol.test.ts
- src/config/constants.ts

This allowed for the `config` and the `process.env` vars to get out of sync, which caused unexpected results for the value of those vars during e2e tests.

This commit consolidates to the `config` as the source of truth for env vars. I've deleted the attempts to set env vars everywhere else.

For convenience, I've added a `.envrc.example` file showing how to set development vars. You can use `direnv allow` to load vars in a .envrc file.[1]

### Skipping `extra-large` fixture e2e test

Recent changes to the api is causing the e2e test to be flaky. The api team is aware and working towards a resolution. Until then, I'm skipping the e2e spec involving that fixture.

[1]https://github.com/direnv/direnv/tree/master