### PR TITLE
fix: ensure url is correct on vscode terminal

### DIFF
--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -94,7 +94,7 @@ export default class ScanEol extends Command {
     const reportCardUrl = config.eolReportUrl;
     const url = ux.colorize(
       'blue',
-      terminalLink(new URL(reportCardUrl).hostname, `${reportCardUrl}/${id}`, { fallback: (url) => url }),
+      terminalLink(new URL(reportCardUrl).hostname, `${reportCardUrl}/${id}`, { fallback: (_, url) => url }),
     );
     this.log(`🌐 View your full EOL report at: ${url}\n`);
   }


### PR DESCRIPTION
Previously, the id was missing:

![Screenshot 2025-06-23 at 10 38 33 AM](https://github.com/user-attachments/assets/a59b2089-30ea-4bcc-8b29-a4e1caba6917)
