### PR TITLE
chore: remap `SUPPORTED` status locally for backwards compatibility

### DIFF
--- a/src/service/nes/nes.svc.ts
+++ b/src/service/nes/nes.svc.ts
@@ -2,6 +2,7 @@ import type { NesApolloClient } from '../../api/nes/nes.client.ts';
 import { M_SCAN } from '../../api/queries/nes/sbom.ts';
 import type { ScanInputOptions, ScanResult } from '../../api/types/hd-cli.types.ts';
 import type {
+  ComponentStatus,
   InsightsEolScanComponent,
   InsightsEolScanInput,
   InsightsEolScanResult,
@@ -12,10 +13,12 @@ import { debugLogger } from '../log.svc.ts';
 export const buildScanResult = (scan: InsightsEolScanResult): ScanResult => {
   const components = new Map<string, InsightsEolScanComponent>();
   for (const c of scan.components) {
+    const status = c.info.status as ComponentStatus | 'SUPPORTED';
     components.set(c.purl, {
       info: {
         ...c.info,
         nesAvailable: c.remediation !== null,
+        status: status === 'SUPPORTED' ? 'EOL_UPCOMING' : status,
       },
       purl: c.purl,
     });


### PR DESCRIPTION
The API change to rename `SUPPORTED` to `EOL_UPCOMING` was reverted for backwards compatibility. Since we do want to use that name for display purposes, we remap it here instead of reverting the related commit, ensuring the expected value is displayed in the JSON report as well.