### PR TITLE
feat: add version command properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@oclif/core": "^4.5.2",
         "@oclif/plugin-help": "^6.2.32",
         "@oclif/plugin-update": "^4.7.4",
-        "@oclif/plugin-version": "^2.2.32",
         "graphql": "^16.11.0",
         "node-machine-id": "^1.1.12",
         "ora": "^8.2.0",
@@ -4008,19 +4007,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
-      }
-    },
-    "node_modules/@oclif/plugin-version": {
-      "version": "2.2.32",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-version/-/plugin-version-2.2.32.tgz",
-      "integrity": "sha512-KwsEKjb202nthRIwigyvRNQ5vK8mUr/FnPzBjkLX7SbgPMLM7iqoaWDPZqBvq5/A/226Ey4vCf64y3zJh4eaWA==",
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/core": "^4",
-        "ansis": "^3.17.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@oclif/plugin-warn-if-update-available": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@oclif/core": "^4.5.2",
     "@oclif/plugin-help": "^6.2.32",
     "@oclif/plugin-update": "^4.7.4",
-    "@oclif/plugin-version": "^2.2.32",
     "graphql": "^16.11.0",
     "node-machine-id": "^1.1.12",
     "ora": "^8.2.0",
@@ -85,13 +84,15 @@
     "plugins": [
       "@oclif/plugin-help",
       "@oclif/plugin-plugins",
-      "@oclif/plugin-update",
-      "@oclif/plugin-version"
+      "@oclif/plugin-update"
     ],
     "hooks": {
-      "init": "./dist/hooks/npm-update-notifier.js",
-      "prerun": "./dist/hooks/prerun.js",
-      "finally": "./dist/hooks/finally.js"
+      "init": [
+        "./dist/hooks/init/00_npm-update-notifier.js",
+        "./dist/hooks/init/01_initialize_amplitude.js"
+      ],
+      "prerun": "./dist/hooks/prerun/prerun.js",
+      "finally": "./dist/hooks/finally/finally.js"
     },
     "topicSeparator": " ",
     "macos": {

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -52,7 +52,7 @@ export default class ScanEol extends Command {
       default: false,
       description: `Save the generated SBOM as ${filenamePrefix}.sbom.json in the scanned directory`,
     }),
-    version: Flags.version()
+    version: Flags.version(),
   };
 
   public async run(): Promise<EolReport | undefined> {

--- a/src/hooks/finally/finally.ts
+++ b/src/hooks/finally/finally.ts
@@ -1,11 +1,11 @@
 import type { Hook } from '@oclif/core';
-import ora from 'ora';
-import { track } from '../service/analytics.svc.ts';
+import ora, { type Ora } from 'ora';
+import { track } from '../../service/analytics.svc.ts';
 
 const hook: Hook<'finally'> = async (opts) => {
-  const isHelpOrVersionCmd = opts.argv.includes('--help') || opts.argv.includes('--version') || opts.Command?.id === 'version'
-  
-  let spinner;
+  const isHelpOrVersionCmd = opts.argv.includes('--help') || opts.argv.includes('--version');
+
+  let spinner: Ora | undefined;
 
   if (!isHelpOrVersionCmd) {
     spinner = ora().start('Cleaning up');
@@ -20,7 +20,6 @@ const hook: Hook<'finally'> = async (opts) => {
     await event;
     spinner?.stop();
   }
-
 };
 
 export default hook;

--- a/src/hooks/init/00_npm-update-notifier.ts
+++ b/src/hooks/init/00_npm-update-notifier.ts
@@ -1,7 +1,7 @@
 import type { Hook } from '@oclif/core';
 import updateNotifier, { type UpdateInfo } from 'update-notifier';
-import pkg from '../../package.json' with { type: 'json' };
-import { debugLogger } from '../service/log.svc.ts';
+import pkg from '../../../package.json' with { type: 'json' };
+import { debugLogger } from '../../service/log.svc.ts';
 
 const updateNotifierHook: Hook.Init = async (options) => {
   debugLogger('pkg.version', pkg.version);

--- a/src/hooks/init/01_initialize_amplitude.ts
+++ b/src/hooks/init/01_initialize_amplitude.ts
@@ -1,9 +1,8 @@
 import { parseArgs } from 'node:util';
 import type { Hook } from '@oclif/core';
-import debug from 'debug';
-import { initializeAnalytics, track } from '../service/analytics.svc.ts';
+import { initializeAnalytics, track } from '../../service/analytics.svc.ts';
 
-const hook: Hook<'prerun'> = async (opts) => {
+const hook: Hook.Init = async () => {
   const args = parseArgs({ allowPositionals: true, strict: false });
   initializeAnalytics();
   track('CLI Command Submitted', (context) => ({
@@ -14,11 +13,6 @@ const hook: Hook<'prerun'> = async (opts) => {
     cli_version: context.cli_version,
     started_at: context.started_at,
   }));
-
-  // If JSON flag is enabled, silence debug logging
-  if (opts.Command.prototype.jsonEnabled()) {
-    debug.disable();
-  }
 };
 
 export default hook;

--- a/src/hooks/prerun/prerun.ts
+++ b/src/hooks/prerun/prerun.ts
@@ -1,0 +1,11 @@
+import type { Hook } from '@oclif/core';
+import debug from 'debug';
+
+const hook: Hook<'prerun'> = async (opts) => {
+  // If JSON flag is enabled, silence debug logging
+  if (opts.Command.prototype.jsonEnabled()) {
+    debug.disable();
+  }
+};
+
+export default hook;

--- a/test/hooks/npm-update-notifier.test.ts
+++ b/test/hooks/npm-update-notifier.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { getDistTag, handleUpdate } from '../../src/hooks/npm-update-notifier.ts';
+import { getDistTag, handleUpdate } from '../../src/hooks/init/00_npm-update-notifier';
 
 describe('getDistTag', () => {
   it('should return beta for beta versions', () => {


### PR DESCRIPTION
- Fix an issue where the `--version` flag did not work
- Fix an issue where the CLI would show the cleaning up spinner unnecessarily
- Fix an issue where the CLI would hang on unknown commands