### PR TITLE
chore: add demo docker scan workflows

### DIFF
--- a/.github/workflows/demo-build-and-scan-docker-image.yml
+++ b/.github/workflows/demo-build-and-scan-docker-image.yml
@@ -1,0 +1,66 @@
+name: (DEMO) HeroDevs CLI Build and Scan Docker Image
+
+on:
+  workflow_dispatch: {}
+
+env:
+  TRACKING_OPT_OUT: 'true'
+  CDXGEN_DEBUG_MODE: 'debug' # recommended for more verbose output from cdxgen
+
+jobs:
+  build-and-sbom:
+    name: Build and Generate SBOM
+    environment: demo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install cdxgen
+        run: npm install -g @cyclonedx/cdxgen
+
+      - name: Build Docker image
+        working-directory: ${{ github.workspace }}
+        run: docker build -f ./ci/demo.Dockerfile -t herodevs/demo-image:local .
+
+      - name: Generate SBOM for local Docker image
+        run: cdxgen -t docker -o sbom.json -r herodevs/demo-image:local
+
+      - name: Verify SBOM exists
+        run: ls -l sbom.json
+      
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdxgen-sbom-json
+          path: sbom.json
+
+  scan-sbom:
+    name: Run HD Scan
+    runs-on: ubuntu-latest
+    needs: build-and-sbom
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cdxgen-sbom-json
+          path: .
+
+      - name: Run EOL scan
+        run: npx @herodevs/cli@beta scan eol --file=sbom.json --save
+
+      - name: Upload HD report
+        uses: actions/upload-artifact@v4
+        with:
+          name: herodevs-report
+          path: ./herodevs.report.json

--- a/.github/workflows/demo-scan-docker-image.yml
+++ b/.github/workflows/demo-scan-docker-image.yml
@@ -1,0 +1,62 @@
+name: (DEMO) HeroDevs CLI Scan Docker Image
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  packages: read
+
+env:
+  TRACKING_OPT_OUT: 'true'
+  CDXGEN_DEBUG_MODE: 'debug' # recommended for more verbose output from cdxgen
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM From Docker Image
+    environment: demo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install cdxgen
+        run: npm install -g @cyclonedx/cdxgen
+
+      - name: Pull Docker image
+        run: docker pull mcr.microsoft.com/playwright:v1.50.0-noble
+
+      - name: Generate SBOM for Docker image
+        run: cdxgen -t docker -o sbom.json -r mcr.microsoft.com/playwright:v1.50.0-noble
+      
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdxgen-sbom-json
+          path: sbom.json
+
+  scan-sbom:
+    name: Run HeroDevs EOL Scan
+    runs-on: ubuntu-latest
+    needs: generate-sbom
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cdxgen-sbom-json
+          path: .
+
+      - name: Run EOL scan
+        run: npx @herodevs/cli@beta scan eol --file=sbom.json --save
+
+      - name: Upload HD report
+        uses: actions/upload-artifact@v4
+        with:
+          name: herodevs-report
+          path: herodevs.report.json

--- a/.github/workflows/demo-scan-with-image.yml
+++ b/.github/workflows/demo-scan-with-image.yml
@@ -1,0 +1,31 @@
+name: (DEMO) HeroDevs EOL Scan With Docker Image
+
+on:
+  workflow_dispatch: {}
+
+env:
+  TRACKING_OPT_OUT: 'true'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    environment: demo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make workspace writable
+        run: chmod -R 777 $GITHUB_WORKSPACE
+
+      - name: Run EOL Scan
+        run: |
+          docker run --rm \
+            -v $GITHUB_WORKSPACE:/app \
+            -w /app \
+            ghcr.io/herodevs/eol-scan --save
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: my-eol-report
+          path: ./herodevs.report.json

--- a/.github/workflows/demo-scan.yaml
+++ b/.github/workflows/demo-scan.yaml
@@ -1,0 +1,28 @@
+name: (DEMO) HeroDevs EOL Scan NPX
+
+on:
+  workflow_dispatch: {}
+
+env:
+  TRACKING_OPT_OUT: 'true'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    environment: demo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run EOL Scan
+        run: npx @herodevs/cli@beta scan eol --save
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: my-eol-report
+          path: ./herodevs.report.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ pnpm-lock.yaml
 **/packages/cli-*/bin/
 **/tsconfig.tsbuildinfo
 .envrc
+
+# Various SBOM Test Output Files
+herodevs.report.json
+herodevs.sbom.json
+bom.json
+sbom.json

--- a/README.md
+++ b/README.md
@@ -215,19 +215,23 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    environment: demo
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Run EOL Scan with Docker
-        uses: docker://ghcr.io/herodevs/eol-scan
-        with:
-          args: "-s"
-      
-      - name: Upload   artifact
+      - name: Run EOL Scan
+        run: |
+          docker run --rm \
+            -v $GITHUB_WORKSPACE:/app \
+            -w /app \
+            ghcr.io/herodevs/eol-scan --save
+
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: my-eol-report
-          path: herodevs.report.json
+          path: ./herodevs.report.json
 ```
 
 #### GitLab CI/CD
@@ -273,14 +277,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - run: echo # Prepare environment, install tooling, perform setup, etc.
 
       - name: Run EOL Scan
-        run: npx @herodevs/cli@beta
+        run: npx @herodevs/cli@beta scan eol
 
-      - name: Upload   artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: my-eol-report

--- a/ci/demo.Dockerfile
+++ b/ci/demo.Dockerfile
@@ -1,0 +1,5 @@
+# This image is used in the demo GitHub workflows to show a minimal docker image scan
+
+FROM mcr.microsoft.com/playwright:v1.50.0-noble
+WORKDIR /app
+CMD ["node", "--version"]


### PR DESCRIPTION
Create a series of demo workflows that show how you can use the HeroDevs CLI in GitHub Actions CI Pipelines.

Demo Workflows Include:

- Basic scan of your repository via `npx`
- Basic scan using built scanner docker image
- Scanning a public Docker image, using `cdxgen` to generate the SBOM
- Building and scanning a docker image in CI, using `cdxgen` to generate the SBOM
