### PR TITLE
chore: skip ci on readme only updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '*.md'
 
 jobs:
   commit-lint:


### PR DESCRIPTION
changing the README and other markdown documents does not affect the build or functionality of the application, such that CI would fail