### PR TITLE
chore(amplitude): Disables scan_location from all amplitude events. #365

### DIFF
--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -61,7 +61,6 @@ export default class ScanEol extends Command {
     track('CLI EOL Scan Started', (context) => ({
       command: context.command,
       command_flags: context.command_flags,
-      scan_location: flags.dir,
     }));
 
     const sbomStartTime = performance.now();
@@ -72,7 +71,6 @@ export default class ScanEol extends Command {
       track('CLI SBOM Generated', (context) => ({
         command: context.command,
         command_flags: context.command_flags,
-        scan_location: flags.dir,
         sbom_generation_time: (sbomEndTime - sbomStartTime) / 1000,
       }));
     }
@@ -91,7 +89,6 @@ export default class ScanEol extends Command {
       track('CLI EOL Scan Ended, No Components Found', (context) => ({
         command: context.command,
         command_flags: context.command_flags,
-        scan_location: flags.dir,
       }));
       this.log('No components found in scan. Report not generated.');
       return;
@@ -110,7 +107,6 @@ export default class ScanEol extends Command {
       nes_available_count: componentCounts.NES_AVAILABLE,
       number_of_packages: componentCounts.TOTAL,
       sbom_created: !flags.file,
-      scan_location: flags.dir,
       scan_load_time: (scanEndTime - scanStartTime) / 1000,
       scanned_ecosystems: componentCounts.ECOSYSTEMS,
       web_report_link: scan.id ? `${config.eolReportUrl}/${scan.id}` : undefined,
@@ -162,7 +158,6 @@ export default class ScanEol extends Command {
       track('CLI EOL Scan Failed', (context) => ({
         command: context.command,
         command_flags: context.command_flags,
-        scan_location: context.scan_location,
         scan_failure_reason: errorMessage,
       }));
       this.error(`Failed to submit scan to NES. ${errorMessage}`);

--- a/src/service/analytics.svc.ts
+++ b/src/service/analytics.svc.ts
@@ -24,7 +24,6 @@ interface AnalyticsContext {
   error?: string;
 
   // Scan Results
-  scan_location?: string;
   eol_true_count?: number;
   eol_unknown_count?: number;
   nes_available_count?: number;

--- a/test/service/analytics.svc.test.ts
+++ b/test/service/analytics.svc.test.ts
@@ -116,7 +116,7 @@ describe('analytics.svc', () => {
 
     it('should call amplitude track with event name and properties when getProperties returns data', async (t) => {
       const mod = await setupModule(t);
-      const testProperties = { scan_location: '/test/path', eol_true_count: 5 };
+      const testProperties = { eol_true_count: 5 };
       const getProperties = sinon.stub().returns(testProperties);
 
       mod.track('test-event', getProperties);
@@ -131,13 +131,12 @@ describe('analytics.svc', () => {
 
     it('should merge properties into analyticsContext when getProperties returns data', async (t) => {
       const mod = await setupModule(t);
-      const firstProperties = { scan_location: '/test/path1', eol_true_count: 3 };
-      const secondProperties = { scan_location: '/test/path2', eol_unknown_count: 2 };
+      const firstProperties = { eol_true_count: 3 };
+      const secondProperties = { eol_unknown_count: 2 };
 
       mod.track('test-event-1', () => firstProperties);
 
       const getSecondProperties = sinon.stub().callsFake((context) => {
-        assert.strictEqual(context.scan_location, '/test/path1');
         assert.strictEqual(context.eol_true_count, 3);
         return secondProperties;
       });
@@ -150,12 +149,11 @@ describe('analytics.svc', () => {
 
     it('should preserve existing analyticsContext when getProperties returns undefined', async (t) => {
       const mod = await setupModule(t);
-      const initialProperties = { scan_location: '/test/path', eol_true_count: 5 };
+      const initialProperties = { eol_true_count: 5 };
 
       mod.track('test-event-1', () => initialProperties);
 
       const getUndefinedProperties = sinon.stub().callsFake((context) => {
-        assert.strictEqual(context.scan_location, '/test/path');
         assert.strictEqual(context.eol_true_count, 5);
         return undefined;
       });


### PR DESCRIPTION
There are a handful of events that provide a "scan_location" property. To foster trust and adoption within our existing customer base, we will temporarily disable the "scan_location" property until we have established user accounts.