### PR TITLE
feat: add trimmed logs and flag to save it

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ DESCRIPTION
   Display help for hd.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.32/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.33/src/commands/help.ts)_
 
 ## `hd scan eol`
 
@@ -112,14 +112,15 @@ Scan a given SBOM for EOL data
 
 ```
 USAGE
-  $ hd scan eol [--json] [-f <value> | -d <value>] [-s] [--saveSbom] [--version]
+  $ hd scan eol [--json] [-f <value> | -d <value>] [-s] [--saveSbom] [--saveTrimmedSbom] [--version]
 
 FLAGS
-  -d, --dir=<value>   [default: <current directory>] The directory to scan in order to create a cyclonedx SBOM
-  -f, --file=<value>  The file path of an existing cyclonedx SBOM to scan for EOL
-  -s, --save          Save the generated report as herodevs.report.json in the scanned directory
-      --saveSbom      Save the generated SBOM as herodevs.sbom.json in the scanned directory
-      --version       Show CLI version.
+  -d, --dir=<value>      [default: <current directory>] The directory to scan in order to create a cyclonedx SBOM
+  -f, --file=<value>     The file path of an existing cyclonedx SBOM to scan for EOL
+  -s, --save             Save the generated report as herodevs.report.json in the scanned directory
+      --saveSbom         Save the generated SBOM as herodevs.sbom.json in the scanned directory
+      --saveTrimmedSbom  Save the trimmed SBOM as herodevs.sbom-trimmed.json in the scanned directory
+      --version          Show CLI version.
 
 GLOBAL FLAGS
   --json  Format output as json.
@@ -189,7 +190,7 @@ EXAMPLES
     $ hd update --available
 ```
 
-_See code: [@oclif/plugin-update](https://github.com/oclif/plugin-update/blob/v4.7.4/src/commands/update.ts)_
+_See code: [@oclif/plugin-update](https://github.com/oclif/plugin-update/blob/v4.7.8/src/commands/update.ts)_
 <!-- commandsstop -->
 
 ## CI/CD Usage

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -6,8 +6,19 @@ import { submitScan } from '../../api/nes.client.ts';
 import { config, filenamePrefix } from '../../config/constants.ts';
 import { track } from '../../service/analytics.svc.ts';
 import { createSbom } from '../../service/cdx.svc.ts';
-import { countComponentsByStatus, formatScanResults, formatWebReportUrl } from '../../service/display.svc.ts';
-import { readSbomFromFile, saveReportToFile, saveSbomToFile, validateDirectory } from '../../service/file.svc.ts';
+import {
+  countComponentsByStatus,
+  formatDataPrivacyLink,
+  formatScanResults,
+  formatWebReportUrl,
+} from '../../service/display.svc.ts';
+import {
+  readSbomFromFile,
+  saveReportToFile,
+  saveSbomToFile,
+  saveTrimmedSbomToFile,
+  validateDirectory,
+} from '../../service/file.svc.ts';
 import { getErrorMessage } from '../../service/log.svc.ts';
 
 export default class ScanEol extends Command {
@@ -51,6 +62,11 @@ export default class ScanEol extends Command {
       aliases: ['save-sbom'],
       default: false,
       description: `Save the generated SBOM as ${filenamePrefix}.sbom.json in the scanned directory`,
+    }),
+    saveTrimmedSbom: Flags.boolean({
+      aliases: ['save-trimmed-sbom'],
+      default: false,
+      description: `Save the trimmed SBOM as ${filenamePrefix}.sbom-trimmed.json in the scanned directory`,
     }),
     version: Flags.version(),
   };
@@ -151,9 +167,24 @@ export default class ScanEol extends Command {
   }
 
   private async scanSbom(sbom: CdxBom): Promise<EolReport> {
-    const spinner = ora().start('Scanning for EOL packages');
+    const { flags } = await this.parse(ScanEol);
+
+    const spinner = ora().start('Trimming SBOM');
+    const trimmedSbom = trimCdxBom(sbom);
+    spinner.succeed('SBOM trimmed');
+
+    if (flags.saveTrimmedSbom) {
+      const trimmedPath = this.saveTrimmedSbom(flags.dir, trimmedSbom);
+      this.log(`Trimmed SBOM saved to ${trimmedPath}`);
+      track('CLI Trimmed SBOM Output Saved', (context) => ({
+        command: context.command,
+        command_flags: context.command_flags,
+      }));
+    }
+
+    spinner.start('Scanning for EOL packages');
     try {
-      const scan = await submitScan({ sbom: trimCdxBom(sbom) });
+      const scan = await submitScan({ sbom: trimmedSbom });
       spinner.succeed('Scan completed');
       return scan;
     } catch (error) {
@@ -189,6 +220,16 @@ export default class ScanEol extends Command {
     }
   }
 
+  private saveTrimmedSbom(dir: string, sbom: CdxBom): string {
+    try {
+      return saveTrimmedSbomToFile(dir, sbom);
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      track('CLI Error Encountered', () => ({ error: errorMessage }));
+      this.error(errorMessage);
+    }
+  }
+
   private displayResults(report: EolReport): void {
     const lines = formatScanResults(report);
     for (const line of lines) {
@@ -200,6 +241,11 @@ export default class ScanEol extends Command {
       for (const line of lines) {
         this.log(line);
       }
+    }
+
+    const privacyLines = formatDataPrivacyLink();
+    for (const line of privacyLines) {
+      this.log(line);
     }
 
     this.log('* Use --json to output the report payload');

--- a/src/service/display.svc.ts
+++ b/src/service/display.svc.ts
@@ -95,3 +95,16 @@ export function formatWebReportUrl(id: string, reportCardUrl: string): string[] 
 
   return [ux.colorize('bold', '-'.repeat(40)), `🌐 View your full EOL report at: ${url}\n`];
 }
+
+/**
+ * Formats data privacy information link for console display
+ */
+export function formatDataPrivacyLink(): string[] {
+  const privacyUrl = 'https://docs.herodevs.com/eol-ds/data-privacy-and-security';
+  const link = ux.colorize(
+    'blue',
+    terminalLink('Learn more about data privacy', privacyUrl, { fallback: (text, url) => `${text}: ${url}` }),
+  );
+
+  return [`🔒 ${link}\n`];
+}

--- a/src/service/file.svc.ts
+++ b/src/service/file.svc.ts
@@ -62,6 +62,20 @@ export function saveSbomToFile(dir: string, sbom: CdxBom): string {
 }
 
 /**
+ * Saves a trimmed SBOM to a file in the specified directory
+ */
+export function saveTrimmedSbomToFile(dir: string, sbom: CdxBom): string {
+  const outputPath = join(dir, `${filenamePrefix}.sbom-trimmed.json`);
+
+  try {
+    fs.writeFileSync(outputPath, JSON.stringify(sbom, null, 2));
+    return outputPath;
+  } catch (error) {
+    throw new Error(`Failed to save trimmed SBOM: ${getErrorMessage(error)}`);
+  }
+}
+
+/**
  * Saves an EOL report to a file in the specified directory
  */
 export function saveReportToFile(dir: string, report: EolReport): string {

--- a/test/service/display.svc.test.ts
+++ b/test/service/display.svc.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import type { EolReport } from '@herodevs/eol-shared';
-import { countComponentsByStatus, formatScanResults, formatWebReportUrl } from '../../src/service/display.svc.ts';
+import {
+  countComponentsByStatus,
+  formatDataPrivacyLink,
+  formatScanResults,
+  formatWebReportUrl,
+} from '../../src/service/display.svc.ts';
 
 describe('display.svc', () => {
   const mockReport: EolReport = {
@@ -146,6 +151,22 @@ describe('display.svc', () => {
 
       assert.ok(lines[1].includes('reports.herodevs.com'));
       assert.ok(lines[1].includes('another-id'));
+    });
+  });
+
+  describe('formatDataPrivacyLink', () => {
+    it('should return array with privacy link', () => {
+      const lines = formatDataPrivacyLink();
+
+      assert.strictEqual(lines.length, 1);
+      assert.ok(lines[0].includes('🔒'));
+      assert.ok(lines[0].includes('Learn more about data privacy'));
+    });
+
+    it('should include HeroDevs documentation URL', () => {
+      const lines = formatDataPrivacyLink();
+
+      assert.ok(lines[0].includes('docs.herodevs.com/eol-ds/data-privacy-and-security'));
     });
   });
 });

--- a/test/service/file.svc.test.ts
+++ b/test/service/file.svc.test.ts
@@ -5,7 +5,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, describe, it } from 'node:test';
 import type { CdxBom, EolReport } from '@herodevs/eol-shared';
-import { readSbomFromFile, saveReportToFile, saveSbomToFile, validateDirectory } from '../../src/service/file.svc.ts';
+import {
+  readSbomFromFile,
+  saveReportToFile,
+  saveSbomToFile,
+  saveTrimmedSbomToFile,
+  validateDirectory,
+} from '../../src/service/file.svc.ts';
 
 describe('file.svc', () => {
   let tempDir: string;
@@ -93,6 +99,28 @@ describe('file.svc', () => {
       const outputPath = saveSbomToFile(tempDir, mockSbom);
 
       assert.ok(outputPath.endsWith('herodevs.sbom.json'));
+      assert.ok(outputPath.includes(tempDir));
+    });
+  });
+
+  describe('saveTrimmedSbomToFile', () => {
+    it('should save trimmed SBOM to file successfully', async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'file-svc-test-'));
+
+      const outputPath = saveTrimmedSbomToFile(tempDir, mockSbom);
+
+      assert.ok(fs.existsSync(outputPath));
+      const content = fs.readFileSync(outputPath, 'utf8');
+      const parsed = JSON.parse(content);
+      assert.deepStrictEqual(parsed, mockSbom);
+    });
+
+    it('should return the correct output path', async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'file-svc-test-'));
+
+      const outputPath = saveTrimmedSbomToFile(tempDir, mockSbom);
+
+      assert.ok(outputPath.endsWith('herodevs.sbom-trimmed.json'));
       assert.ok(outputPath.includes(tempDir));
     });
   });


### PR DESCRIPTION
### Summary
Adds SBOM privacy transparency features to improve user confidence about what data is sent to HeroDevs during EOL scans.

### What Changed
1. New `--saveTrimmedSbom` Flag
Allows users to save the exact SBOM payload sent as herodevs.sbom-trimmed.json
Users can inspect exactly what data is being transmitted
2. Visual Privacy Indicators
Added "Trimming SBOM" status message during scan execution
3. Data Privacy Documentation Link
Added privacy link to scan output: 🔒 Learn more about data privacy: https://docs.herodevs.com/eol-ds/data-privacy-and-security
Clickable in terminals that support hyperlinks
Displayed after scan results, hidden in --json mode

### User Impact
Users can now:
- Verify exactly what data is sent using --saveTrimmedSbom
- See clear visual indicators that data is being sanitized
- Access comprehensive privacy documentation with one click

### Example Usage
#### Save the trimmed SBOM to verify what's sent
`hd scan eol --saveTrimmedSbom`

#### Save all artifacts (report, SBOM, and trimmed SBOM)
`hd scan eol --save --saveSbom --saveTrimmedSbom`