### PR TITLE
feat: add support for spdx sbom input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ USAGE
   $ hd scan eol [--json] [-f <value> | -d <value>] [-s] [--saveSbom] [--saveTrimmedSbom] [--hideReportUrl] [--version]
 
 FLAGS
-  -d, --dir=<value>      [default: <current directory>] The directory to scan in order to create a cyclonedx SBOM
-  -f, --file=<value>     The file path of an existing cyclonedx SBOM to scan for EOL
+  -d, --dir=<value>      [default: <current directory>] The directory to scan in order to scan for EOL
+  -f, --file=<value>     The file path of an existing SBOM to scan for EOL (supports CycloneDX and SPDX 2.3 formats)
   -s, --save             Save the generated report as herodevs.report.json in the scanned directory
       --hideReportUrl    Hide the generated web report URL for this scan
       --saveSbom         Save the generated SBOM as herodevs.sbom.json in the scanned directory

--- a/e2e/fixtures/npm/simple-spdx.sbom.json
+++ b/e2e/fixtures/npm/simple-spdx.sbom.json
@@ -1,0 +1,37 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "simple-npm-project",
+  "documentNamespace": "https://example.com/simple-npm-project",
+  "creationInfo": {
+    "created": "2024-01-01T00:00:00Z",
+    "creators": ["Tool: test"]
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-bootstrap-3.1.1",
+      "name": "bootstrap",
+      "versionInfo": "3.1.1",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/bootstrap@3.1.1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-vue-3.5.13",
+      "name": "vue",
+      "versionInfo": "3.5.13",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/vue@3.5.13"
+        }
+      ]
+    }
+  ]
+}

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -44,7 +44,7 @@ export default class ScanEol extends Command {
   static override flags = {
     file: Flags.string({
       char: 'f',
-      description: 'The file path of an existing cyclonedx SBOM to scan for EOL',
+      description: 'The file path of an existing SBOM to scan for EOL (supports CycloneDX and SPDX 2.3 formats)',
       exclusive: ['dir'],
     }),
     dir: Flags.string({


### PR DESCRIPTION
# SPDX SBOM Support

## Summary

Added support for SPDX 2.3 SBOM format to the `--file` flag, allowing users to scan SPDX SBOMs in addition to CycloneDX SBOMs.

### What changed

- Updated `readSbomFromFile()` to support both SPDX 2.3 and CycloneDX formats
- Added format detection logic: checks SPDX first, then CycloneDX
- Returns CycloneDX format consistently for downstream processing
- Enhanced error messages to indicate supported formats
- Updated `--file` flag description to mention SPDX 2.3 support