### PR TITLE
fix: dependabot PRs on e2e and update gitignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/e2e"
+    open-pull-requests-limit: 0
     schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        paths:
-          - "e2e/fixtures/**"
+      interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,11 @@ pnpm-lock.yaml
 **/tsconfig.tsbuildinfo
 .envrc
 
-# Various SBOM Test Output Files
+# Various CLI Output Files
 herodevs.report.json
 herodevs.sbom.json
 bom.json
 sbom.json
 cdx.json
 spdx.json
+hd-tracker


### PR DESCRIPTION
- Update the dependabot config again, to try to prevent it from fixing the intentionally out of date boostrap version in e2e package.json. [Source docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-)
- Add the tracker config files dev test files to the gitignore