### PR TITLE
chore: update eol-shared version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@amplitude/analytics-node": "^1.5.26",
         "@apollo/client": "^4.0.9",
         "@cyclonedx/cdxgen": "^12.0.0",
-        "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.16",
+        "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.17",
         "@inquirer/prompts": "^8.0.2",
         "@napi-rs/keyring": "^1.2.0",
         "@oclif/core": "^4.8.0",
@@ -2422,7 +2422,7 @@
     },
     "node_modules/@herodevs/eol-shared": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/herodevs/eol-shared.git#ee1913a03a73fc6201298ca7ffe14ff91b4c866e",
+      "resolved": "git+ssh://git@github.com/herodevs/eol-shared.git#a940b8eac77edf23ceca854babc7edb115ea6175",
       "license": "ISC",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "^9.4.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@amplitude/analytics-node": "^1.5.26",
     "@apollo/client": "^4.0.9",
     "@cyclonedx/cdxgen": "^12.0.0",
-    "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.16",
+    "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.17",
     "@inquirer/prompts": "^8.0.2",
     "@napi-rs/keyring": "^1.2.0",
     "@oclif/core": "^4.8.0",


### PR DESCRIPTION
New eol-shared version improves metadata component name resolution during SPDX to CycloneDX conversion