### PR TITLE
feat: add login success message

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -52,6 +52,8 @@ export default class AuthLogin extends Command {
     } catch (error) {
       this.error(`User setup failed. ${getErrorMessage(error)}`);
     }
+
+    this.log('\nLogin completed successfully.');
   }
 
   private startServerAndAwaitCode(authUrl: string, expectedState: string): Promise<string> {


### PR DESCRIPTION
Adding a small indication of success to login command, it wasn't clear whether the command succeeded or errored after login.