### PR TITLE
fix(auth): prevent ERR_SERVER_NOT_RUNNING on magic-link login; harden stopServer

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -6,7 +6,7 @@ import { Command } from '@oclif/core';
 import { ensureUserSetup } from '../../api/user-setup.client.ts';
 import { persistTokenResponse } from '../../service/auth.svc.ts';
 import { getClientId, getRealmUrl } from '../../service/auth-config.svc.ts';
-import { getErrorMessage } from '../../service/log.svc.ts';
+import { debugLogger, getErrorMessage } from '../../service/log.svc.ts';
 import type { TokenResponse } from '../../types/auth.ts';
 import { openInBrowser } from '../../utils/open-in-browser.ts';
 
@@ -14,6 +14,7 @@ export default class AuthLogin extends Command {
   static description = 'OAuth CLI login';
 
   private server?: http.Server;
+  private stopServerPromise?: Promise<void>;
   private readonly port = parseInt(process.env.OAUTH_CALLBACK_PORT || '4000', 10);
   private readonly redirectUri = process.env.OAUTH_CALLBACK_REDIRECT || `http://localhost:${this.port}/oauth2/callback`;
   private readonly realmUrl = getRealmUrl();
@@ -136,11 +137,59 @@ export default class AuthLogin extends Command {
     });
   }
 
-  private async stopServer() {
-    if (this.server) {
-      await new Promise<void>((resolve, reject) => this.server?.close((err) => (err ? reject(err) : resolve())));
-      this.server = undefined;
+  private stopServer(): Promise<void> {
+    if (this.stopServerPromise) {
+      return this.stopServerPromise;
     }
+
+    const server = this.server;
+    this.server = undefined;
+
+    if (!server) {
+      return Promise.resolve();
+    }
+
+    const stopPromise = new Promise<void>((resolve) => {
+      const timeoutMs = 1000;
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+
+      const complete = (err?: Error) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = undefined;
+        }
+
+        const code = (err as NodeJS.ErrnoException | undefined)?.code;
+        if (err && code !== 'ERR_SERVER_NOT_RUNNING') {
+          this.warn('Failed to stop local OAuth callback server.');
+          debugLogger('Failed to stop local OAuth callback server: %s', getErrorMessage(err));
+        }
+
+        resolve();
+      };
+
+      timeout = setTimeout(() => {
+        debugLogger('Timed out while stopping local OAuth callback server after %dms', timeoutMs);
+        complete();
+      }, timeoutMs);
+
+      try {
+        server.close((err) => complete(err));
+      } catch (err) {
+        complete(err as Error);
+      }
+    }).finally(() => {
+      this.stopServerPromise = undefined;
+    });
+
+    this.stopServerPromise = stopPromise;
+    return stopPromise;
   }
 
   private async exchangeCodeForToken(code: string, codeVerifier: string): Promise<TokenResponse> {


### PR DESCRIPTION
Closes https://github.com/neverendingsupport/data-and-integrations/issues/549

## Summary

This PR fixes a local CLI auth regression where `auth login` could throw:

`Error [ERR_SERVER_NOT_RUNNING]: Server is not running.`

even though authentication completed successfully (most visible in magic-link flows).

## Root Cause

The OAuth callback server shutdown (`server.close`) was not resilient to re-entrant/racing shutdown paths:

- callback success path triggered shutdown
- error path could also trigger shutdown shortly after

When `close()` was called on an already-closed server, Node returned `ERR_SERVER_NOT_RUNNING`.  
Because shutdown was not fully guarded, this surfaced as an exception during CLI login.

## Changes

- Added `stopServerPromise` to deduplicate concurrent shutdown attempts.
- Refactored `stopServer()` to be idempotent:
  - capture server reference once
  - clear `this.server` early
  - return existing in-flight shutdown promise when present
- Treated `ERR_SERVER_NOT_RUNNING` as benign during cleanup.
- Kept user-facing warning generic (`Failed to stop local OAuth callback server.`) and moved detailed error info to debug logs.
- Updated non-awaited shutdown calls to explicit fire-and-forget (`void this.stopServer()`) where applicable.

## Why This Approach

- Prevents false-negative CLI failures during successful auth flows.
- Makes shutdown logic deterministic and safe under event races.
- Keeps CLI output clean for users while preserving debuggability for maintainers.