### PR TITLE
fix(analytics): include scan_load_time for failed scan events

### DIFF
--- a/test/commands/scan/eol.analytics.test.ts
+++ b/test/commands/scan/eol.analytics.test.ts
@@ -135,6 +135,7 @@ describe('scan:eol analytics timing', () => {
     expect(properties.scan_failure_reason).toBe('GraphQL request timed out after 60000ms');
     expect(properties.scan_load_time).toEqual(expect.any(Number));
     expect(properties.scan_load_time as number).toBeGreaterThanOrEqual(0);
+    expect(properties.number_of_packages).toBe(1);
   });
 
   it('tracks scan_load_time on ApiError scan failures', async () => {
@@ -154,6 +155,7 @@ describe('scan:eol analytics timing', () => {
     expect(properties.scan_failure_reason).toBe('FORBIDDEN');
     expect(properties.scan_load_time).toEqual(expect.any(Number));
     expect(properties.scan_load_time as number).toBeGreaterThanOrEqual(0);
+    expect(properties.number_of_packages).toBe(1);
   });
 
   it('keeps scan_load_time on successful completion events', async () => {


### PR DESCRIPTION
## Summary
This PR adds scan duration telemetry for failed scan flows while keeping the analytics schema consistent by reusing `scan_load_time` for success and failure events.

## Notes
- No telemetry event names were changed.
- No non-scan analytics flows were modified.

Closes: https://github.com/neverendingsupport/data-and-integrations/issues/547
