### PR TITLE
feat(cli): unify Amplitude identify flow and enforce cli event source

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -5,6 +5,7 @@ import { URL } from 'node:url';
 import { Command } from '@oclif/core';
 import { ensureUserSetup } from '../../api/user-setup.client.ts';
 import { OAUTH_CALLBACK_ERROR_CODES } from '../../config/constants.ts';
+import { refreshIdentityFromStoredToken } from '../../service/analytics.svc.ts';
 import { persistTokenResponse } from '../../service/auth.svc.ts';
 import { getClientId, getRealmUrl } from '../../service/auth-config.svc.ts';
 import { debugLogger, getErrorMessage } from '../../service/log.svc.ts';
@@ -53,6 +54,12 @@ export default class AuthLogin extends Command {
       await ensureUserSetup({ preferOAuth: true });
     } catch (error) {
       this.error(`User setup failed. ${getErrorMessage(error)}`);
+    }
+
+    try {
+      await refreshIdentityFromStoredToken();
+    } catch (error) {
+      this.warn(`Failed to refresh analytics identity: ${getErrorMessage(error)}`);
     }
 
     this.log('\nLogin completed successfully.');

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -1,4 +1,5 @@
 import { Command } from '@oclif/core';
+import { clearTrackedIdentity } from '../../service/analytics.svc.ts';
 import { logoutFromProvider } from '../../service/auth-refresh.svc.ts';
 import { clearStoredTokens, getStoredTokens } from '../../service/auth-token.svc.ts';
 
@@ -23,6 +24,7 @@ export default class AuthLogout extends Command {
       this.warn(`Failed to revoke tokens remotely: ${error instanceof Error ? error.message : error}`);
     }
 
+    clearTrackedIdentity();
     await clearStoredTokens();
     this.log('Local authentication tokens removed from your system.');
   }

--- a/src/hooks/finally/finally.ts
+++ b/src/hooks/finally/finally.ts
@@ -1,6 +1,7 @@
 import type { Hook } from '@oclif/core';
 import ora, { type Ora } from 'ora';
 import { track } from '../../service/analytics.svc.ts';
+import { debugLogger, getErrorMessage } from '../../service/log.svc.ts';
 
 const hook: Hook<'finally'> = async (opts) => {
   const isHelpOrVersionCmd = opts.argv.includes('--help') || opts.argv.includes('--version');
@@ -12,10 +13,14 @@ const hook: Hook<'finally'> = async (opts) => {
     spinner = ora().start('Cleaning up');
   }
 
-  await track('CLI Session Ended', (context) => ({
-    cli_version: context.cli_version,
-    ended_at: new Date(),
-  })).promise;
+  try {
+    await track('CLI Session Ended', (context) => ({
+      cli_version: context.cli_version,
+      ended_at: new Date(),
+    })).promise;
+  } catch (error) {
+    debugLogger('Failed to track CLI session end: %s', getErrorMessage(error));
+  }
 
   if (!isHelpOrVersionCmd && !hasError) {
     spinner?.stop();

--- a/src/hooks/init/01_initialize_amplitude.ts
+++ b/src/hooks/init/01_initialize_amplitude.ts
@@ -1,18 +1,28 @@
 import { parseArgs } from 'node:util';
 import type { Hook } from '@oclif/core';
 import { initializeAnalytics, track } from '../../service/analytics.svc.ts';
+import { debugLogger, getErrorMessage } from '../../service/log.svc.ts';
 
 const hook: Hook.Init = async () => {
   const args = parseArgs({ allowPositionals: true, strict: false });
-  initializeAnalytics();
-  track('CLI Command Submitted', (context) => ({
-    command: args.positionals.join(' ').trim(),
-    command_flags: Object.entries(args.values).flat().join(' '),
-    app_used: context.app_used,
-    ci_provider: context.ci_provider,
-    cli_version: context.cli_version,
-    started_at: context.started_at,
-  }));
+  try {
+    await initializeAnalytics();
+  } catch (error) {
+    debugLogger('Failed to initialize analytics in init hook: %s', getErrorMessage(error));
+  }
+
+  try {
+    track('CLI Command Submitted', (context) => ({
+      command: args.positionals.join(' ').trim(),
+      command_flags: Object.entries(args.values).flat().join(' '),
+      app_used: context.app_used,
+      ci_provider: context.ci_provider,
+      cli_version: context.cli_version,
+      started_at: context.started_at,
+    }));
+  } catch (error) {
+    debugLogger('Failed to track command submission: %s', getErrorMessage(error));
+  }
 };
 
 export default hook;

--- a/src/service/analytics.svc.ts
+++ b/src/service/analytics.svc.ts
@@ -1,11 +1,19 @@
+import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import { track as _track, Identify, identify, init, setOptOut, Types } from '@amplitude/analytics-node';
 import NodeMachineId from 'node-machine-id';
 import { config } from '../config/constants.ts';
+import { getStoredTokens, type StoredTokens } from './auth-token.svc.ts';
+import { decodeJwtPayload } from './jwt.svc.ts';
+import { debugLogger, getErrorMessage } from './log.svc.ts';
 
-const device_id = NodeMachineId.machineIdSync(true);
+const SOURCE = 'cli';
+
+const device_id = resolveDeviceId();
 const started_at = new Date();
 const session_id = started_at.getTime();
+const IDENTITY_FIELDS: (keyof IdentityClaims)[] = ['email', 'organization_name', 'role', 'user_id'];
+const CONTEXT_IDENTITY_FIELDS: (keyof AnalyticsContext)[] = ['email', 'organization_name', 'role', 'user_id'];
 
 interface AnalyticsContext {
   // Session & Identity
@@ -14,6 +22,10 @@ interface AnalyticsContext {
   os_release?: string;
   started_at?: Date;
   ended_at?: Date;
+  email?: string;
+  organization_name?: string;
+  role?: string;
+  user_id?: string;
 
   // CLI Context
   app_used?: string;
@@ -36,6 +48,8 @@ interface AnalyticsContext {
   web_report_link?: string;
 }
 
+type IdentityClaims = Pick<AnalyticsContext, 'email' | 'organization_name' | 'role' | 'user_id'>;
+
 const defaultAnalyticsContext: AnalyticsContext = {
   locale: Intl.DateTimeFormat().resolvedOptions().locale,
   os_platform: os.platform(),
@@ -47,31 +61,223 @@ const defaultAnalyticsContext: AnalyticsContext = {
 };
 
 let analyticsContext: AnalyticsContext = defaultAnalyticsContext;
+let identifiedUserId: string | undefined;
+let lastIdentitySignature = '';
 
-export function initializeAnalytics() {
-  init('0', {
-    flushQueueSize: 2,
-    flushIntervalMillis: 250,
-    logLevel: Types.LogLevel.None,
-    serverUrl: config.analyticsUrl,
-  });
-  setOptOut(process.env.TRACKING_OPT_OUT === 'true');
-  identify(new Identify(), {
-    device_id,
-    platform: analyticsContext.os_platform,
-    os_name: getOSName(analyticsContext.os_platform ?? ''),
-    os_version: analyticsContext.os_release,
-    session_id,
-    app_version: analyticsContext.cli_version,
-  });
+export async function initializeAnalytics(): Promise<void> {
+  try {
+    await toSafeAnalyticsResult(
+      init('0', {
+        flushQueueSize: 2,
+        flushIntervalMillis: 250,
+        logLevel: Types.LogLevel.None,
+        serverUrl: config.analyticsUrl,
+      }),
+      'init',
+    ).promise;
+    void toSafeAnalyticsResult(setOptOut(process.env.TRACKING_OPT_OUT === 'true'), 'setOptOut').promise;
+
+    const identifiedFromToken = await refreshIdentityFromStoredToken();
+    if (!identifiedFromToken) {
+      void toSafeAnalyticsResult(identify(new Identify(), buildIdentifyEventOptions()), 'identify-anonymous').promise;
+    }
+  } catch (error) {
+    logAnalyticsError('initialize', error);
+  }
+}
+
+export async function refreshIdentityFromStoredToken(): Promise<boolean> {
+  try {
+    const tokens = await getStoredTokens();
+    const claims = resolveIdentityClaims(tokens);
+    if (!claims) {
+      clearTrackedIdentity();
+      return false;
+    }
+
+    const entries = toIdentityEntries(claims);
+    const signature = buildIdentitySignature(entries);
+    if (signature === lastIdentitySignature) {
+      return false;
+    }
+    applyIdentityClaims(claims, signature);
+    emitIdentify(entries, claims.user_id);
+    return true;
+  } catch (error) {
+    logAnalyticsError('refreshIdentityFromStoredToken', error);
+    return false;
+  }
+}
+
+export function clearTrackedIdentity(): void {
+  identifiedUserId = undefined;
+  lastIdentitySignature = '';
+  analyticsContext = clearIdentityFromContext(analyticsContext);
 }
 
 export function track(event: string, getProperties?: (context: AnalyticsContext) => Partial<AnalyticsContext>) {
-  const localContext = getProperties?.(analyticsContext);
-  if (localContext) {
-    analyticsContext = { ...analyticsContext, ...localContext };
+  try {
+    const localContext = getProperties?.(analyticsContext);
+    if (localContext) {
+      analyticsContext = { ...analyticsContext, ...localContext };
+    }
+
+    const eventProperties = { source: SOURCE, ...(localContext ?? {}) };
+    return toSafeAnalyticsResult(
+      _track(event, eventProperties, buildEventOptions(identifiedUserId || analyticsContext.user_id)),
+      `track:${event}`,
+    );
+  } catch (error) {
+    logAnalyticsError(`track:${event}`, error);
+    return toSafeAnalyticsResult(undefined, `track:${event}:noop`);
   }
-  return _track(event, localContext, { device_id, session_id });
+}
+
+function buildEventOptions(userId?: string) {
+  if (userId) {
+    return { device_id, session_id, user_id: userId };
+  }
+  return { device_id, session_id };
+}
+
+function buildIdentifyEventOptions(userId?: string) {
+  return {
+    ...buildEventOptions(userId),
+    platform: analyticsContext.os_platform,
+    os_name: getOSName(analyticsContext.os_platform ?? ''),
+    os_version: analyticsContext.os_release,
+    app_version: analyticsContext.cli_version,
+  };
+}
+
+function normalizeClaim(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+}
+
+function extractIdentityClaims(accessToken: string | undefined): IdentityClaims | undefined {
+  const payload = decodeJwtPayload(accessToken);
+  if (!payload) {
+    return;
+  }
+
+  const identity: IdentityClaims = {
+    user_id: normalizeClaim(payload.sub) || undefined,
+    email: normalizeClaim(payload.email) || undefined,
+    organization_name: normalizeClaim(payload.company) || undefined,
+    role: normalizeClaim(payload.role) || undefined,
+  };
+
+  if (toIdentityEntries(identity).length === 0) {
+    return;
+  }
+
+  return identity;
+}
+
+function resolveIdentityClaims(tokens: StoredTokens | undefined): IdentityClaims | undefined {
+  const tokenCandidates = new Set(
+    [tokens?.accessToken, config.ciTokenFromEnv].map((token) => normalizeClaim(token)).filter(Boolean),
+  );
+
+  for (const tokenCandidate of tokenCandidates) {
+    const claims = extractIdentityClaims(tokenCandidate);
+    if (claims) {
+      return claims;
+    }
+  }
+
+  return;
+}
+
+function toIdentityEntries(identity: IdentityClaims): Array<[keyof IdentityClaims, string]> {
+  const entries: Array<[keyof IdentityClaims, string]> = [];
+  for (const field of IDENTITY_FIELDS) {
+    const value = identity[field];
+    if (value) {
+      entries.push([field, value]);
+    }
+  }
+  return entries;
+}
+
+function buildIdentitySignature(entries: Array<[keyof IdentityClaims, string]>): string {
+  return entries.map(([field, value]) => `${field}:${value}`).join('|');
+}
+
+function applyIdentityClaims(claims: IdentityClaims, signature: string): void {
+  identifiedUserId = claims.user_id;
+  lastIdentitySignature = signature;
+  analyticsContext = { ...analyticsContext, ...claims };
+}
+
+function emitIdentify(entries: Array<[keyof IdentityClaims, string]>, userId?: string): void {
+  const amplitudeIdentify = new Identify();
+  for (const [field, value] of entries) {
+    amplitudeIdentify.set(field, value);
+  }
+
+  const eventOptions = buildIdentifyEventOptions(userId);
+  void toSafeAnalyticsResult(identify(amplitudeIdentify, eventOptions), 'identify').promise;
+  void toSafeAnalyticsResult(_track('Identify Call', { source: SOURCE }, eventOptions), 'track:Identify Call').promise;
+}
+
+function resolveDeviceId(): string {
+  try {
+    return NodeMachineId.machineIdSync(true);
+  } catch (error) {
+    logAnalyticsError('resolveDeviceId', error);
+    return randomUUID();
+  }
+}
+
+function toSafeAnalyticsResult(
+  result: unknown,
+  operation: string,
+): {
+  promise: Promise<void>;
+} {
+  const resultPromise = extractResultPromise(result);
+  if (!resultPromise) {
+    return { promise: Promise.resolve() };
+  }
+
+  return {
+    promise: resultPromise
+      .then(() => undefined)
+      .catch((error) => {
+        logAnalyticsError(operation, error);
+      }),
+  };
+}
+
+function extractResultPromise(result: unknown): Promise<unknown> | undefined {
+  if (!result || typeof result !== 'object') {
+    return;
+  }
+
+  const candidate = (result as { promise?: unknown }).promise;
+  if (candidate instanceof Promise) {
+    return candidate;
+  }
+
+  if (candidate && typeof (candidate as { then?: unknown }).then === 'function') {
+    return candidate as Promise<unknown>;
+  }
+}
+
+function logAnalyticsError(operation: string, error: unknown): void {
+  debugLogger('Analytics operation failed (%s): %s', operation, getErrorMessage(error));
+}
+
+function clearIdentityFromContext(context: AnalyticsContext): AnalyticsContext {
+  const nextContext = { ...context };
+  for (const field of CONTEXT_IDENTITY_FIELDS) {
+    delete nextContext[field];
+  }
+  return nextContext;
 }
 
 function getCIProvider(env = process.env): string | undefined {

--- a/src/service/jwt.svc.ts
+++ b/src/service/jwt.svc.ts
@@ -1,0 +1,21 @@
+export function decodeJwtPayload(token: string | undefined): Record<string, unknown> | undefined {
+  if (!token) {
+    return;
+  }
+
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2 || !parts[1]) {
+      return;
+    }
+
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as unknown;
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return;
+    }
+
+    return payload as Record<string, unknown>;
+  } catch {
+    return;
+  }
+}

--- a/test/commands/auth/logout.test.ts
+++ b/test/commands/auth/logout.test.ts
@@ -11,7 +11,13 @@ vi.mock('../../../src/service/auth-refresh.svc.ts', () => ({
   logoutFromProvider: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../../../src/service/analytics.svc.ts', () => ({
+  __esModule: true,
+  clearTrackedIdentity: vi.fn(),
+}));
+
 import AuthLogout from '../../../src/commands/auth/logout.ts';
+import { clearTrackedIdentity } from '../../../src/service/analytics.svc.ts';
 import { logoutFromProvider } from '../../../src/service/auth-refresh.svc.ts';
 import { clearStoredTokens, getStoredTokens } from '../../../src/service/auth-token.svc.ts';
 
@@ -29,6 +35,7 @@ describe('AuthLogout command', () => {
 
     expect(logSpy).toHaveBeenCalledWith('No stored authentication tokens found.');
     expect(clearStoredTokens).not.toHaveBeenCalled();
+    expect(clearTrackedIdentity).not.toHaveBeenCalled();
   });
 
   it('revokes tokens and clears local storage', async () => {
@@ -39,6 +46,7 @@ describe('AuthLogout command', () => {
     await command.run();
 
     expect(logoutFromProvider).toHaveBeenCalledWith('refresh');
+    expect(clearTrackedIdentity).toHaveBeenCalledTimes(1);
     expect(clearStoredTokens).toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith('Local authentication tokens removed from your system.');
   });
@@ -52,6 +60,7 @@ describe('AuthLogout command', () => {
     await command.run();
 
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('network fail'));
+    expect(clearTrackedIdentity).toHaveBeenCalledTimes(1);
     expect(clearStoredTokens).toHaveBeenCalled();
   });
 });

--- a/test/service/auth.svc.test.ts
+++ b/test/service/auth.svc.test.ts
@@ -3,7 +3,6 @@ import { type Mock, vi } from 'vitest';
 const { mockConfig } = vi.hoisted(() => ({
   mockConfig: {
     ciTokenFromEnv: undefined as string | undefined,
-    accessTokenFromEnv: undefined as string | undefined,
   },
 }));
 
@@ -61,7 +60,6 @@ describe('auth.svc', () => {
     vi.resetAllMocks();
     (getCIToken as Mock).mockReturnValue(undefined);
     mockConfig.ciTokenFromEnv = undefined;
-    mockConfig.accessTokenFromEnv = undefined;
   });
 
   it('persists token responses via keyring service', async () => {

--- a/test/service/ci-auth.svc.test.ts
+++ b/test/service/ci-auth.svc.test.ts
@@ -3,7 +3,6 @@ import { type Mock, vi } from 'vitest';
 const { mockConfig } = vi.hoisted(() => ({
   mockConfig: {
     ciTokenFromEnv: undefined as string | undefined,
-    accessTokenFromEnv: undefined as string | undefined,
   },
 }));
 
@@ -36,7 +35,6 @@ describe('ci-auth.svc', () => {
     vi.resetAllMocks();
     (getCIToken as Mock).mockReturnValue(undefined);
     mockConfig.ciTokenFromEnv = undefined;
-    mockConfig.accessTokenFromEnv = undefined;
   });
 
   it('does not saveCIToken when token comes from env', async () => {

--- a/test/service/jwt.svc.test.ts
+++ b/test/service/jwt.svc.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { decodeJwtPayload } from '../../src/service/jwt.svc.ts';
+
+function createJwtToken(payload: unknown): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${encodedPayload}.signature`;
+}
+
+describe('jwt.svc', () => {
+  describe('decodeJwtPayload', () => {
+    it('returns decoded payload for a valid JWT', () => {
+      const token = createJwtToken({
+        sub: 'user-1',
+        email: 'dev@herodevs.com',
+      });
+
+      expect(decodeJwtPayload(token)).toEqual({
+        sub: 'user-1',
+        email: 'dev@herodevs.com',
+      });
+    });
+
+    it('returns undefined when token is missing', () => {
+      expect(decodeJwtPayload(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when token format is invalid', () => {
+      expect(decodeJwtPayload('not-a-jwt')).toBeUndefined();
+      expect(decodeJwtPayload('header..signature')).toBeUndefined();
+    });
+
+    it('returns undefined when payload is not valid JSON', () => {
+      const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+      const invalidJsonPayload = Buffer.from('not-json').toString('base64url');
+
+      expect(decodeJwtPayload(`${header}.${invalidJsonPayload}.signature`)).toBeUndefined();
+    });
+
+    it('returns undefined when payload is not an object', () => {
+      expect(decodeJwtPayload(createJwtToken('string-payload'))).toBeUndefined();
+      expect(decodeJwtPayload(createJwtToken(['array-payload']))).toBeUndefined();
+      expect(decodeJwtPayload(createJwtToken(123))).toBeUndefined();
+      expect(decodeJwtPayload(createJwtToken(null))).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens CLI Amplitude identity handling so event ordering is deterministic, identity claims are mapped from canonical token fields, and JWT decoding logic is shared instead of duplicated.

## What Changed

### Analytics initialization and event ordering

- Updated the init hook to `await initializeAnalytics()` before sending `CLI Command Submitted`.
- Prevents race conditions where the first event could be emitted before identity resolution.

### Identity resolution from auth tokens

- Added token-based identity refresh via `refreshIdentityFromStoredToken()`.
- Identity mapping now uses canonical claim sources only:
  - `user_id` from `sub`
  - `email` from `email`
  - `organization_name` from `company`
  - `role` from `role`
- Non-canonical aliases are intentionally ignored to reduce fallback ambiguity.

### Shared JWT payload decoder

- Introduced `src/service/jwt.svc.ts` with `decodeJwtPayload(token)` for safe payload parsing.
- Reused it in:
  - `src/service/analytics.svc.ts` for identity extraction
  - `src/service/auth-token.svc.ts` for access-token expiry checks

### Identify behavior (dedupe + metadata)

- Keep runtime identify metadata in identify options:
  - `device_id`, `session_id`, `platform`, `os_name`, `os_version`, `app_version`
- Emit only one identify call during initialization:
  - token-based identify when identity claims exist
  - fallback metadata-only identify when claims are unavailable
- Added signature-based dedupe so repeated identity refreshes with the same identity do not re-emit identify.

### Tracking contract hardening

- Enforced `source=cli` for all tracked events.
- `Identify Call` is emitted with `source=cli` and event options including `user_id` when available.
- Preserved user identity propagation into event options for subsequent tracked events.

### Login flow integration

- After successful `auth login`, the command now calls `refreshIdentityFromStoredToken()` to bind analytics identity immediately for post-login telemetry.
- Failure to refresh identity is handled as a warning and does not block login success.

Issue: https://github.com/neverendingsupport/data-and-integrations/issues/573