### PR TITLE
fix: user setup using wrong token for login and ci provision

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -4,6 +4,7 @@ import { createInterface } from 'node:readline';
 import { URL } from 'node:url';
 import { Command } from '@oclif/core';
 import { ensureUserSetup } from '../../api/user-setup.client.ts';
+import { config } from '../../config/constants.ts';
 import { persistTokenResponse } from '../../service/auth.svc.ts';
 import { getClientId, getRealmUrl } from '../../service/auth-config.svc.ts';
 import { debugLogger, getErrorMessage } from '../../service/log.svc.ts';
@@ -48,10 +49,12 @@ export default class AuthLogin extends Command {
       return;
     }
 
-    try {
-      await ensureUserSetup();
-    } catch (error) {
-      this.error(`User setup failed. ${getErrorMessage(error)}`);
+    if (config.enableUserSetup) {
+      try {
+        await ensureUserSetup({ preferOAuth: true });
+      } catch (error) {
+        this.error(`User setup failed. ${getErrorMessage(error)}`);
+      }
     }
 
     this.log('\nLogin completed successfully.');

--- a/src/commands/auth/provision-ci-token.ts
+++ b/src/commands/auth/provision-ci-token.ts
@@ -19,7 +19,7 @@ export default class AuthProvisionCiToken extends Command {
 
     let orgId: number;
     try {
-      orgId = await ensureUserSetup();
+      orgId = await ensureUserSetup({ preferOAuth: true });
     } catch (error) {
       this.error(`User setup failed. ${getErrorMessage(error)}`);
     }

--- a/test/api/user-setup.client.test.ts
+++ b/test/api/user-setup.client.test.ts
@@ -25,6 +25,15 @@ describe('user-setup.client', () => {
     await expect(getUserSetupStatus()).resolves.toEqual({ isComplete: true, orgId: 42 });
   });
 
+  it('uses keyring when preferOAuth true', async () => {
+    fetchMock.addGraphQL({ eol: { userSetupStatus: { isComplete: true, orgId: 99 } } });
+
+    await expect(getUserSetupStatus({ preferOAuth: true })).resolves.toEqual({
+      isComplete: true,
+      orgId: 99,
+    });
+  });
+
   it('completes user setup when status is false and returns orgId', async () => {
     fetchMock
       .addGraphQL({ eol: { userSetupStatus: { isComplete: false } } })

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -87,6 +87,14 @@ vi.mock('../../../src/api/user-setup.client.ts', () => ({
   ensureUserSetup: vi.fn(),
 }));
 
+vi.mock('../../../src/config/constants.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/config/constants')>();
+  return {
+    ...actual,
+    config: { ...actual.config, enableUserSetup: true },
+  };
+});
+
 vi.mock('../../../src/utils/open-in-browser.ts', () => ({
   __esModule: true,
   openInBrowser: vi.fn(),
@@ -410,6 +418,7 @@ describe('AuthLogin', () => {
 
       expect(persistTokenResponseMock).toHaveBeenCalledWith(tokenResponse);
       expect(ensureUserSetupMock).toHaveBeenCalledTimes(1);
+      expect(ensureUserSetupMock).toHaveBeenCalledWith({ preferOAuth: true });
     });
 
     it('runs user setup after login', async () => {
@@ -425,6 +434,7 @@ describe('AuthLogin', () => {
       await command.run();
 
       expect(ensureUserSetupMock).toHaveBeenCalledTimes(1);
+      expect(ensureUserSetupMock).toHaveBeenCalledWith({ preferOAuth: true });
     });
 
     it('fails login when user setup fails', async () => {

--- a/test/commands/auth/provision-ci-token.test.ts
+++ b/test/commands/auth/provision-ci-token.test.ts
@@ -60,7 +60,7 @@ describe('AuthProvisionCiToken command', () => {
     await command.run();
 
     expect(requireAccessToken).toHaveBeenCalled();
-    expect(ensureUserSetup).toHaveBeenCalled();
+    expect(ensureUserSetup).toHaveBeenCalledWith({ preferOAuth: true });
     expect(provisionCIToken).toHaveBeenCalledWith({ orgId: 123 });
     expect(saveCIToken).toHaveBeenCalledWith('new-ci-refresh-token');
     expect(saveCIOrgId).toHaveBeenCalledWith(123);
@@ -81,6 +81,7 @@ describe('AuthProvisionCiToken command', () => {
 
     await command.run();
 
+    expect(ensureUserSetup).toHaveBeenCalledWith({ preferOAuth: true });
     expect(provisionCIToken).toHaveBeenCalledWith({ orgId: 456 });
     expect(saveCIOrgId).toHaveBeenCalledWith(456);
   });


### PR DESCRIPTION
# Prioritize Login Token for User Setup

## Summary

When running `hd auth login` with a CI token already stored, user setup now uses the OAuth (keyring) token instead of the CI token, so user setup completes for the freshly logged-in identity.

## Problem

Previously, `getUserSetupStatus` used the CI token (via `requireAccessTokenForScan`) when `getCIToken()` returned a value, even during `hd auth login`. The user setup would run with the wrong identity.

## Solution

Added a `preferOAuth` option that flows from the login and provision commands down to `getUserSetupStatus` and `completeUserSetup`. When `preferOAuth: true`, the keyring token is always used regardless of CI token.

## Changes

### `src/api/user-setup.client.ts`

- **`getUserSetupStatus(options?: { preferOAuth?: boolean })`** – When `preferOAuth` is true, uses `requireAccessToken` (keyring); otherwise keeps existing logic (CI/env → `requireAccessTokenForScan`, else `requireAccessToken`).
- **`completeUserSetup(options?: { preferOAuth?: boolean })`** – Same `preferOAuth` behavior for consistency.
- **`ensureUserSetup(options?: { preferOAuth?: boolean })`** – Passes options through to both calls.
- **Refactor** – Extracted `getTokenProvider()` helper; replaced nested ternaries with clearer if/else logic.

### `src/commands/auth/login.ts`

- Calls `ensureUserSetup({ preferOAuth: true })` when `config.enableUserSetup` is true.

### `src/commands/auth/provision-ci-token.ts`

- Calls `ensureUserSetup({ preferOAuth: true })` for the interactive OAuth session.

### Tests

- `test/api/user-setup.client.test.ts` – Added test for `getUserSetupStatus({ preferOAuth: true })` using keyring when CI token exists.
- `test/commands/auth/login.test.ts` – Ensures `ensureUserSetup` is called with `{ preferOAuth: true }` (mocked `config.enableUserSetup`).
- `test/commands/auth/provision-ci-token.test.ts` – Asserts `ensureUserSetup` is called with `{ preferOAuth: true }`.

