### PR TITLE
ci: switch AWS auth step to OIDC

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -105,9 +105,10 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          role-to-assume: ${{ vars.aws_oidc_role_arn }}
+          role-session-name: herodevs_cli_upload
+          aws-region: ${{ vars.AWS_REGION }}
+
 
       - name: Upload and promote to S3
         run: |


### PR DESCRIPTION
Move upload process to auth via OIDC instead of a stored secret

Related to https://github.com/neverendingsupport/infra-terraform/pull/566