### PR TITLE
fix: eol shared global install issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@amplitude/analytics-node": "^1.5.26",
         "@apollo/client": "^4.0.9",
         "@cyclonedx/cdxgen": "^12.1.1",
-        "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.17",
+        "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.18",
         "@inquirer/prompts": "^8.0.2",
         "@napi-rs/keyring": "^1.2.0",
         "@oclif/core": "^4.8.0",
@@ -2395,7 +2395,7 @@
     },
     "node_modules/@herodevs/eol-shared": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/herodevs/eol-shared.git#a940b8eac77edf23ceca854babc7edb115ea6175",
+      "resolved": "git+ssh://git@github.com/herodevs/eol-shared.git#d09fced611e00f141c134909634052674adbeea7",
       "license": "ISC",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "^9.4.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@amplitude/analytics-node": "^1.5.26",
     "@apollo/client": "^4.0.9",
     "@cyclonedx/cdxgen": "^12.1.1",
-    "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.17",
+    "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.18",
     "@inquirer/prompts": "^8.0.2",
     "@napi-rs/keyring": "^1.2.0",
     "@oclif/core": "^4.8.0",


### PR DESCRIPTION
there are errors caused installing the herodevs CLI globally, because of this package. The tag that is referenced in a github repository, doesn't point to a revision that has the built dist already. because of this, it requires a user to have typescript installed globally to build from source.

this now references a tag that is the same as 0.1.17, but pointing to the build artifacts instead. There are no functional changes to eol-shared in this PR: https://github.com/herodevs/eol-shared/tree/v0.1.18