### PR TITLE
feat: skip ci on workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-      - '*.md'
+    paths:
+      - '**'                          # include everything by default
+      - '!**/*.md'                    # ignore markdown files
+      - '!.github/workflows/**'       # ignore all workflow files
+      - '.github/workflows/ci.yml'    # except changes to ci.yml itself
 
 jobs:
   commit-lint:


### PR DESCRIPTION
it was tedious waiting for CI while we improved the manual release flow, let's not do that anymore