### PR TITLE
fix: revert cdxgen image

### DIFF
--- a/ci/image.Dockerfile
+++ b/ci/image.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cyclonedx/cdxgen:v12.1.1
+FROM ghcr.io/cyclonedx/cdxgen:v12.0.0
 ENV NODE_NO_WARNINGS=1 \
     NPM_CONFIG_UPDATE_NOTIFIER=false \
     NPM_CONFIG_LOGLEVEL=error


### PR DESCRIPTION
apparently, there is no `12.1.1` of cdxgen image, even though they have that version as a package json

https://github.com/orgs/CycloneDX/packages/container/cdxgen/versions