### PR TITLE
chore: update dependabot config to ignore e2e

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "npm"
-    directory: "/e2e"
-    open-pull-requests-limit: 0
+    directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '**'                          # include everything by default
       - '!**/*.md'                    # ignore markdown files
-      - '!.github/workflows/**'       # ignore all workflow files
+      - '!.github/**'                 # ignore all .github/ files
       - '.github/workflows/ci.yml'    # except changes to ci.yml itself
 
 jobs:


### PR DESCRIPTION
- another attempt to get dependabot to ignore that e2e directory with intentionally bad dependencies
- update the CI skipping to include dependabot config. changing dependabot shouldn't re-run all tests