### PR TITLE
fix: classify CI token refresh communication failures

### DIFF
--- a/src/api/ci-token.client.ts
+++ b/src/api/ci-token.client.ts
@@ -25,6 +25,13 @@ export interface ProvisionCITokenOptions {
   previousToken?: string | null;
 }
 
+export class CITokenCommunicationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CITokenCommunicationError';
+  }
+}
+
 type GetOrgAccessTokensResponse = {
   iamV2?: {
     access?: {
@@ -39,29 +46,45 @@ function extractErrorCode(errors: ReadonlyArray<GraphQLFormattedError>): ApiErro
   return code;
 }
 
+function classifyCiTokenError(
+  errors: ReadonlyArray<GraphQLFormattedError> | undefined,
+  error: unknown,
+  fallbackMessage: string,
+): Error {
+  if (errors?.length) {
+    const message = errors[0].message ?? fallbackMessage;
+    const code = extractErrorCode(errors);
+    if (code) {
+      return new ApiError(message, code);
+    }
+
+    return new CITokenCommunicationError(message);
+  }
+
+  const message = error instanceof Error ? error.message : error ? String(error) : fallbackMessage;
+  return new CITokenCommunicationError(message || fallbackMessage);
+}
+
 async function getOrgAccessTokens(
   input: IamAccessOrgTokensInput,
 ): Promise<{ accessToken: string; refreshToken: string }> {
   const client = createApollo(graphqlUrl, requireAccessToken);
-  const res = await client.mutate<GetOrgAccessTokensResponse, { input: IamAccessOrgTokensInput }>({
-    mutation: getOrgAccessTokensMutation,
-    variables: {
-      input,
-    },
-  });
+  let res: Awaited<ReturnType<typeof client.mutate<GetOrgAccessTokensResponse, { input: IamAccessOrgTokensInput }>>>;
+  try {
+    res = await client.mutate<GetOrgAccessTokensResponse, { input: IamAccessOrgTokensInput }>({
+      mutation: getOrgAccessTokensMutation,
+      variables: {
+        input,
+      },
+    });
+  } catch (error) {
+    throw classifyCiTokenError(undefined, error, 'CI token provisioning failed');
+  }
 
   const errors = getGraphQLErrors(res);
   if (res?.error || errors?.length) {
     debugLogger('Error returned from getOrgAccessTokens mutation: %o', res.error ?? errors);
-    if (errors?.length) {
-      const code = extractErrorCode(errors);
-      if (code) {
-        throw new ApiError(errors[0].message ?? 'CI token provisioning failed', code);
-      }
-      throw new Error(errors[0].message ?? 'CI token provisioning failed');
-    }
-    const msg = res?.error instanceof Error ? res.error.message : res?.error ? String(res.error) : '';
-    throw new Error(msg || 'CI token provisioning failed');
+    throw classifyCiTokenError(errors, res?.error, 'CI token provisioning failed');
   }
 
   const tokens = res.data?.iamV2?.access?.getOrgAccessTokens;
@@ -88,28 +111,25 @@ async function callGetOrgAccessTokensInternal(
   tokenProvider: TokenProvider,
 ): Promise<{ accessToken: string; refreshToken: string }> {
   const client = createApollo(graphqlUrl, tokenProvider);
-  const res = await client.mutate<GetOrgAccessTokensResponse, { input: IamAccessOrgTokensInput }>({
-    mutation: getOrgAccessTokensMutation,
-    variables: { input },
-  });
+  let res: Awaited<ReturnType<typeof client.mutate<GetOrgAccessTokensResponse, { input: IamAccessOrgTokensInput }>>>;
+  try {
+    res = await client.mutate<GetOrgAccessTokensResponse, { input: IamAccessOrgTokensInput }>({
+      mutation: getOrgAccessTokensMutation,
+      variables: { input },
+    });
+  } catch (error) {
+    throw classifyCiTokenError(undefined, error, 'CI token refresh failed');
+  }
 
   const errors = getGraphQLErrors(res);
   if (res?.error || errors?.length) {
     debugLogger('Error returned from getOrgAccessTokens mutation: %o', res.error ?? errors);
-    if (errors?.length) {
-      const code = extractErrorCode(errors);
-      if (code) {
-        throw new ApiError(errors[0].message ?? 'CI token refresh failed', code);
-      }
-      throw new Error(errors[0].message ?? 'CI token refresh failed');
-    }
-    const msg = res?.error instanceof Error ? res.error.message : res?.error ? String(res.error) : '';
-    throw new Error(msg || 'CI token refresh failed');
+    throw classifyCiTokenError(errors, res?.error, 'CI token refresh failed');
   }
 
   const tokens = res.data?.iamV2?.access?.getOrgAccessTokens;
   if (!tokens?.accessToken) {
-    throw new Error('getOrgAccessTokens response missing accessToken');
+    throw new CITokenCommunicationError('getOrgAccessTokens response missing accessToken');
   }
 
   return {

--- a/src/commands/scan/eol.ts
+++ b/src/commands/scan/eol.ts
@@ -6,7 +6,7 @@ import { ApiError, PAYLOAD_TOO_LARGE_ERROR_CODE } from '../../api/errors.ts';
 import { submitScan } from '../../api/nes.client.ts';
 import { config, filenamePrefix, SCAN_ORIGIN_AUTOMATED, SCAN_ORIGIN_CLI } from '../../config/constants.ts';
 import { track } from '../../service/analytics.svc.ts';
-import { AUTH_ERROR_MESSAGES, getTokenForScanWithSource } from '../../service/auth.svc.ts';
+import { AUTH_ERROR_MESSAGES, getTokenForScanWithSource, type TokenSource } from '../../service/auth.svc.ts';
 import { createSbom } from '../../service/cdx.svc.ts';
 import {
   countComponentsByStatus,
@@ -87,7 +87,7 @@ export default class ScanEol extends Command {
   public async run(): Promise<EolReport | undefined> {
     const { flags } = await this.parse(ScanEol);
 
-    const { source } = await getTokenForScanWithSource();
+    const { source } = await this.getTokenSourceForScan();
     if (source === 'ci') {
       this.log('CI credentials found');
       this.log('Using CI credentials');
@@ -255,6 +255,14 @@ export default class ScanEol extends Command {
 
   private getScanLoadTime(scanStartTime: number): number {
     return (performance.now() - scanStartTime) / 1000;
+  }
+
+  private async getTokenSourceForScan(): Promise<{ token: string; source: TokenSource }> {
+    try {
+      return await getTokenForScanWithSource();
+    } catch (error) {
+      this.error(getErrorMessage(error));
+    }
   }
 
   private getPayloadTooLargeMessage(hasUserProvidedSbom: boolean): string {

--- a/src/service/ci-auth.svc.ts
+++ b/src/service/ci-auth.svc.ts
@@ -1,12 +1,19 @@
-import { exchangeCITokenForAccess } from '../api/ci-token.client.ts';
+import { CITokenCommunicationError, exchangeCITokenForAccess } from '../api/ci-token.client.ts';
+import { ApiError } from '../api/errors.ts';
 import { config } from '../config/constants.ts';
 import { getCIToken, saveCIToken } from './ci-token.svc.ts';
 import { debugLogger } from './log.svc.ts';
 
-export type CITokenErrorCode = 'CI_TOKEN_INVALID' | 'CI_TOKEN_REFRESH_FAILED' | 'CI_ORG_ID_REQUIRED';
+export type CITokenErrorCode =
+  | 'CI_TOKEN_INVALID'
+  | 'CI_TOKEN_REFRESH_FAILED'
+  | 'CI_TOKEN_COMMUNICATION_FAILED'
+  | 'CI_ORG_ID_REQUIRED';
 
 const CITOKEN_ERROR_MESSAGE =
   "CI token is invalid or expired. To provision a new CI token, run 'hd auth provision-ci-token' (after logging in with 'hd auth login').";
+const CITOKEN_COMMUNICATION_ERROR_MESSAGE =
+  'There was an error communicating with the HeroDevs server while refreshing the CI token. Please verify server connectivity/configuration and try again.';
 
 export class CITokenError extends Error {
   readonly code: CITokenErrorCode;
@@ -34,6 +41,10 @@ export async function requireCIAccessToken(): Promise<string> {
     return result.accessToken;
   } catch (error) {
     debugLogger('CI token refresh failed: %O', error);
+    if (error instanceof CITokenCommunicationError || !(error instanceof Error) || !(error instanceof ApiError)) {
+      throw new CITokenError(CITOKEN_COMMUNICATION_ERROR_MESSAGE, 'CI_TOKEN_COMMUNICATION_FAILED');
+    }
+
     throw new CITokenError(CITOKEN_ERROR_MESSAGE, 'CI_TOKEN_REFRESH_FAILED');
   }
 }

--- a/test/api/ci-token.client.test.ts
+++ b/test/api/ci-token.client.test.ts
@@ -17,10 +17,12 @@ vi.mock('../../src/config/constants.ts', async (importOriginal) => {
 });
 
 import {
+  CITokenCommunicationError,
   exchangeCITokenForAccess,
   getOrgAccessTokensUnauthenticated,
   provisionCIToken,
 } from '../../src/api/ci-token.client.ts';
+import { ApiError } from '../../src/api/errors.ts';
 import { FetchMock } from '../utils/mocks/fetch.mock.ts';
 
 const mockHeaders = {
@@ -48,8 +50,8 @@ function mockGraphQLResponse(data: {
   } as unknown as Response;
 }
 
-function mockGraphQLErrorResponse(message: string) {
-  const payload = { errors: [{ message }] };
+function mockGraphQLErrorResponse(message: string, extensions?: Record<string, unknown>) {
+  const payload = { errors: [{ message, extensions }] };
   return {
     ok: true,
     status: 200,
@@ -220,18 +222,96 @@ describe('ci-token.client', () => {
       });
     });
 
-    it('throws when GraphQL returns errors', async () => {
+    it('treats GraphQL errors without codes as communication errors', async () => {
       fetchMock.push(mockGraphQLErrorResponse('Invalid refresh token'));
 
-      await expect(getOrgAccessTokensUnauthenticated({ previousToken: 'bad-token' })).rejects.toThrow(
-        /Invalid refresh token/,
-      );
+      const promise = getOrgAccessTokensUnauthenticated({ previousToken: 'bad-token' });
+      await expect(promise).rejects.toBeInstanceOf(CITokenCommunicationError);
+      await expect(promise).rejects.toThrow(/Invalid refresh token/);
     });
 
     it('throws when response is not ok', async () => {
       fetchMock.push(mockErrorResponse(500, 'Internal Server Error'));
 
-      await expect(getOrgAccessTokensUnauthenticated({ previousToken: 'token' })).rejects.toThrow(/500/);
+      const promise = getOrgAccessTokensUnauthenticated({ previousToken: 'token' });
+      await expect(promise).rejects.toBeInstanceOf(CITokenCommunicationError);
+      await expect(promise).rejects.toThrow(/500/);
+    });
+
+    it('throws communication error when GraphQL data is null', async () => {
+      fetchMock.push({
+        ok: true,
+        status: 200,
+        headers: mockHeaders,
+        async json() {
+          return { data: null };
+        },
+        async text() {
+          return JSON.stringify({ data: null });
+        },
+      } as unknown as Response);
+
+      const promise = getOrgAccessTokensUnauthenticated({ previousToken: 'token' });
+      await expect(promise).rejects.toBeInstanceOf(CITokenCommunicationError);
+      await expect(promise).rejects.toThrow(/missing accessToken/);
+    });
+
+    it('throws communication error when getOrgAccessTokens is null', async () => {
+      fetchMock.push(
+        mockGraphQLResponse({
+          iamV2: {
+            access: {
+              getOrgAccessTokens: undefined,
+            },
+          },
+        }),
+      );
+
+      const promise = getOrgAccessTokensUnauthenticated({ previousToken: 'token' });
+      await expect(promise).rejects.toBeInstanceOf(CITokenCommunicationError);
+      await expect(promise).rejects.toThrow(/missing accessToken/);
+    });
+
+    it('throws communication error when accessToken is missing', async () => {
+      fetchMock.push(
+        mockGraphQLResponse({
+          iamV2: {
+            access: {
+              getOrgAccessTokens: {
+                refreshToken: 'refresh-only',
+              },
+            },
+          },
+        }),
+      );
+
+      const promise = getOrgAccessTokensUnauthenticated({ previousToken: 'token' });
+      await expect(promise).rejects.toBeInstanceOf(CITokenCommunicationError);
+      await expect(promise).rejects.toThrow(/missing accessToken/);
+    });
+
+    it('throws communication error on fetch failure', async () => {
+      fetchMock.push(Promise.reject(new Error('connect ETIMEDOUT gateway.test')));
+
+      const promise = getOrgAccessTokensUnauthenticated({ previousToken: 'token' });
+      await expect(promise).rejects.toBeInstanceOf(CITokenCommunicationError);
+      await expect(promise).rejects.toThrow(/ETIMEDOUT/);
+    });
+
+    it('treats explicit auth GraphQL codes as ApiError', async () => {
+      fetchMock.push(mockGraphQLErrorResponse('Not authorized', { code: 'UNAUTHENTICATED' }));
+
+      const promise = getOrgAccessTokensUnauthenticated({ previousToken: 'token' });
+      await expect(promise).rejects.toBeInstanceOf(ApiError);
+      await expect(promise).rejects.toThrow(/Not authorized/);
+    });
+
+    it('treats resolver-like GraphQL errors as communication errors', async () => {
+      fetchMock.push(mockGraphQLErrorResponse("Cannot read properties of undefined (reading 'accessToken')"));
+
+      const promise = getOrgAccessTokensUnauthenticated({ previousToken: 'token' });
+      await expect(promise).rejects.toBeInstanceOf(CITokenCommunicationError);
+      await expect(promise).rejects.toThrow(/accessToken/);
     });
   });
 

--- a/test/commands/scan/eol.analytics.test.ts
+++ b/test/commands/scan/eol.analytics.test.ts
@@ -2,6 +2,7 @@ import type { CdxBom, EolReport } from '@herodevs/eol-shared';
 import type { Config } from '@oclif/core';
 import { ApiError, FORBIDDEN_ERROR_CODE, PAYLOAD_TOO_LARGE_ERROR_CODE } from '../../../src/api/errors.ts';
 import ScanEol from '../../../src/commands/scan/eol.ts';
+import { CITokenError } from '../../../src/service/auth.svc.ts';
 
 const {
   trackMock,
@@ -237,5 +238,39 @@ describe('scan:eol analytics timing', () => {
     const properties = getTrackProperties('CLI EOL Scan Completed');
     expect(properties.scan_load_time).toEqual(expect.any(Number));
     expect(properties.scan_load_time as number).toBeGreaterThanOrEqual(0);
+  });
+
+  it('formats CI token errors without exposing the internal error class name', async () => {
+    getTokenForScanWithSourceMock.mockRejectedValue(
+      new CITokenError(
+        'There was an error communicating with the HeroDevs server while refreshing the CI token. Please verify server connectivity/configuration and try again.',
+        'CI_TOKEN_COMMUNICATION_FAILED',
+      ),
+    );
+
+    const command = createCommand();
+    vi.spyOn(command, 'parse').mockResolvedValue({
+      flags: {
+        file: '/tmp/sample.sbom.json',
+        save: false,
+        output: undefined,
+        saveSbom: false,
+        sbomOutput: undefined,
+        saveTrimmedSbom: false,
+        hideReportUrl: false,
+        automated: false,
+      },
+    });
+    const errorSpy = vi.spyOn(command, 'error').mockImplementation((input: string | Error) => {
+      const message = input instanceof Error ? input.message : input;
+      throw new Error(message);
+    });
+
+    await expect(command.run()).rejects.toThrow(
+      'There was an error communicating with the HeroDevs server while refreshing the CI token. Please verify server connectivity/configuration and try again.',
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'There was an error communicating with the HeroDevs server while refreshing the CI token. Please verify server connectivity/configuration and try again.',
+    );
   });
 });

--- a/test/service/auth.svc.test.ts
+++ b/test/service/auth.svc.test.ts
@@ -157,6 +157,21 @@ describe('auth.svc', () => {
       });
     });
 
+    it('propagates communication CITokenError when CI refresh cannot reach the server', async () => {
+      (getCIToken as Mock).mockReturnValue('ci-refresh-token');
+      (requireCIAccessToken as Mock).mockRejectedValue(
+        new CITokenError(
+          'There was an error communicating with the HeroDevs server while refreshing the CI token. Please verify server connectivity/configuration and try again.',
+          'CI_TOKEN_COMMUNICATION_FAILED',
+        ),
+      );
+
+      await expect(requireAccessTokenForScan()).rejects.toMatchObject({
+        name: 'CITokenError',
+        code: 'CI_TOKEN_COMMUNICATION_FAILED',
+      });
+    });
+
     it('returns token when access token is valid (login path)', async () => {
       (getStoredTokens as Mock).mockResolvedValue({ accessToken: 'valid-token' });
       (isAccessTokenExpired as Mock).mockReturnValue(false);

--- a/test/service/ci-auth.svc.test.ts
+++ b/test/service/ci-auth.svc.test.ts
@@ -15,18 +15,14 @@ vi.mock('../../src/service/auth-token.svc.ts', () => ({
   isAccessTokenExpired: vi.fn(),
 }));
 
-vi.mock('../../src/api/ci-token.client.ts', () => ({
-  __esModule: true,
-  exchangeCITokenForAccess: vi.fn(),
-}));
-
 vi.mock('../../src/service/ci-token.svc.ts', () => ({
   __esModule: true,
   getCIToken: vi.fn(),
   saveCIToken: vi.fn(),
 }));
 
-import { exchangeCITokenForAccess } from '../../src/api/ci-token.client.ts';
+import * as ciTokenClient from '../../src/api/ci-token.client.ts';
+import { ApiError, INVALID_TOKEN_ERROR_CODE } from '../../src/api/errors.ts';
 import { requireCIAccessToken } from '../../src/service/ci-auth.svc.ts';
 import { getCIToken, saveCIToken } from '../../src/service/ci-token.svc.ts';
 
@@ -40,7 +36,7 @@ describe('ci-auth.svc', () => {
   it('does not saveCIToken when token comes from env', async () => {
     mockConfig.ciTokenFromEnv = 'env-refresh-token';
     (getCIToken as Mock).mockReturnValue('env-refresh-token');
-    (exchangeCITokenForAccess as Mock).mockResolvedValue({
+    vi.spyOn(ciTokenClient, 'exchangeCITokenForAccess').mockResolvedValue({
       accessToken: 'access',
       refreshToken: 'rotated-refresh',
     });
@@ -56,16 +52,44 @@ describe('ci-auth.svc', () => {
       name: 'CITokenError',
       code: 'CI_TOKEN_INVALID',
     });
-    expect(exchangeCITokenForAccess).not.toHaveBeenCalled();
+    expect(ciTokenClient.exchangeCITokenForAccess).not.toHaveBeenCalled();
   });
 
-  it('throws when exchange fails', async () => {
+  it('throws refresh failure when exchange is explicitly rejected by the server', async () => {
     (getCIToken as Mock).mockReturnValue('ci-refresh-token');
-    (exchangeCITokenForAccess as Mock).mockRejectedValue(new Error('exchange failed'));
+    vi.spyOn(ciTokenClient, 'exchangeCITokenForAccess').mockRejectedValue(
+      new ApiError('Invalid refresh token', INVALID_TOKEN_ERROR_CODE),
+    );
 
     await expect(requireCIAccessToken()).rejects.toMatchObject({
       name: 'CITokenError',
       code: 'CI_TOKEN_REFRESH_FAILED',
+    });
+  });
+
+  it('throws communication failure when exchange returns malformed/null server data', async () => {
+    (getCIToken as Mock).mockReturnValue('ci-refresh-token');
+    vi.spyOn(ciTokenClient, 'exchangeCITokenForAccess').mockRejectedValue(
+      new ciTokenClient.CITokenCommunicationError('getOrgAccessTokens response missing accessToken'),
+    );
+
+    await expect(requireCIAccessToken()).rejects.toMatchObject({
+      name: 'CITokenError',
+      code: 'CI_TOKEN_COMMUNICATION_FAILED',
+      message:
+        'There was an error communicating with the HeroDevs server while refreshing the CI token. Please verify server connectivity/configuration and try again.',
+    });
+  });
+
+  it('defaults unexpected exchange failures to communication failure', async () => {
+    (getCIToken as Mock).mockReturnValue('ci-refresh-token');
+    vi.spyOn(ciTokenClient, 'exchangeCITokenForAccess').mockRejectedValue(
+      new Error('connect ETIMEDOUT gateway.prod.apps.herodevs.io'),
+    );
+
+    await expect(requireCIAccessToken()).rejects.toMatchObject({
+      name: 'CITokenError',
+      code: 'CI_TOKEN_COMMUNICATION_FAILED',
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/neverendingsupport/data-and-integrations/issues/757

## What This Branch Does

This branch improves CI-token refresh failures in the CLI so null, malformed, or transport-level HeroDevs API responses are no longer surfaced as “CI token is invalid or expired.” It adds explicit communication-failure classification in the CI token client, maps those failures to a new CLI-facing error code/message, and keeps `scan eol` output user-facing instead of exposing internal error class names.

## CI Token Refresh Classification

- Adds [`CITokenCommunicationError`](https://github.com/herodevs/cli/pull/546/files#diff-78b5850c98cf0b0b9c51b4bc015366f958b3cef5d02eb2a42b56a486c3fec6ccR28-R33) plus the centralized [`classifyCiTokenError()`](https://github.com/herodevs/cli/pull/546/files#diff-78b5850c98cf0b0b9c51b4bc015366f958b3cef5d02eb2a42b56a486c3fec6ccR49-R66) helper in [`src/api/ci-token.client.ts`](https://github.com/herodevs/cli/pull/546/files#diff-78b5850c98cf0b0b9c51b4bc015366f958b3cef5d02eb2a42b56a486c3fec6cc), so GraphQL responses with no recognized `extensions.code`, null payloads, missing `accessToken`, and transport failures all land in the communication-failure path.
- Wraps both [`getOrgAccessTokens()`](https://github.com/herodevs/cli/pull/546/files#diff-78b5850c98cf0b0b9c51b4bc015366f958b3cef5d02eb2a42b56a486c3fec6ccR68-R99) and [`callGetOrgAccessTokensInternal()`](https://github.com/herodevs/cli/pull/546/files#diff-78b5850c98cf0b0b9c51b4bc015366f958b3cef5d02eb2a42b56a486c3fec6ccR109-R139) in the same classification logic, so provisioning and refresh flows now behave consistently.
- Leaves explicit auth failures on the structured [`ApiError`](https://github.com/herodevs/cli/pull/546/files#diff-78b5850c98cf0b0b9c51b4bc015366f958b3cef5d02eb2a42b56a486c3fec6ccR43-R47) path when the server provides a known GraphQL error code.

## CLI Messaging

- Extends [`CITokenErrorCode`](https://github.com/herodevs/cli/pull/546/files#diff-0bbc4699dcabce352807fd73dc5e698247443b6a5fa3fe690aad601e98ed29a8R7-R17) in [`src/service/ci-auth.svc.ts`](https://github.com/herodevs/cli/pull/546/files#diff-0bbc4699dcabce352807fd73dc5e698247443b6a5fa3fe690aad601e98ed29a8) with `CI_TOKEN_COMMUNICATION_FAILED` and maps [`requireCIAccessToken()`](https://github.com/herodevs/cli/pull/546/files#diff-0bbc4699dcabce352807fd73dc5e698247443b6a5fa3fe690aad601e98ed29a8R28-R49) to the new “error communicating with the HeroDevs server” message for communication-like failures.
- Updates [`ScanEol.run()`](https://github.com/herodevs/cli/pull/546/files#diff-f63e4eb3a2e80a081d7d8b68cc466fac611727ccbbc71ac6910f00ed92e06b5dR87-R99) in [`src/commands/scan/eol.ts`](https://github.com/herodevs/cli/pull/546/files#diff-f63e4eb3a2e80a081d7d8b68cc466fac611727ccbbc71ac6910f00ed92e06b5d) to fetch auth state through the new [`getTokenSourceForScan()`](https://github.com/herodevs/cli/pull/546/files#diff-f63e4eb3a2e80a081d7d8b68cc466fac611727ccbbc71ac6910f00ed92e06b5dR260-R266) helper, so auth/CI failures are rendered with `this.error(getErrorMessage(error))` instead of leaking `CITokenError:` in terminal output.
