### PR TITLE
fix(cli): avoid second OIDC roundtrip after auth login completion

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -34,7 +34,7 @@ export const config = {
   graphqlHost: process.env.GRAPHQL_HOST || 'https://gateway.prod.apps.herodevs.io',
   graphqlPath: process.env.GRAPHQL_PATH || '/graphql',
   analyticsUrl: process.env.ANALYTICS_URL || 'https://apps.herodevs.com/api/eol/track',
-  eolLogInUrl: process.env.EOL_LOG_IN_URL || 'https://apps.herodevs.com/eol/api/auth/cli-log-in',
+  eolLogInUrl: process.env.EOL_LOG_IN_URL || 'https://apps.herodevs.com/eol/cli-logged-in',
   concurrentPageRequests,
   pageSize,
   ciTokenFromEnv: process.env.HD_CI_CREDENTIAL?.trim() || undefined,

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -189,9 +189,13 @@ describe('AuthLogin', () => {
       const server = getLatestServer();
 
       await flushAsync();
-      sendCallbackThroughStub({ code: 'test-code', state });
+      const response = sendCallbackThroughStub({ code: 'test-code', state });
 
       await expect(pendingCode).resolves.toBe(tokenResponse);
+      expect(response.writeHead).toHaveBeenCalledWith(302, {
+        Location: 'https://apps.herodevs.com/eol/cli-logged-in',
+      });
+      expect(response.end).toHaveBeenCalledWith();
       expect(questionMock).toHaveBeenCalledWith(expect.stringContaining(authUrl), expect.any(Function));
       expect(closeMock).toHaveBeenCalledTimes(1);
       expect(openMock).toHaveBeenCalledWith(authUrl);


### PR DESCRIPTION
Closes https://github.com/neverendingsupport/idp/issues/93

## What This Branch Does

This branch removes the extra browser auth roundtrip that happened after `hd auth login` had already completed successfully on the local callback. Instead of sending the browser to the web OAuth callback route, the CLI now finishes on the static `cli-logged-in` page so the user sees a single completion flow.

## CLI Login Completion

- Updated [`config.eolLogInUrl`](https://github.com/herodevs/cli/pull/561/files#diff-143d78eb344aee71bd9eff746283b5b3f8ac16dfe6be2091e29f678324100c00R32-R37) to use `https://apps.herodevs.com/eol/cli-logged-in` instead of `https://apps.herodevs.com/eol/api/auth/cli-log-in`.
- This keeps the existing local PKCE callback behavior intact while preventing the browser from triggering a second OIDC authorization request through the web callback route in [`src/config/constants.ts`](https://github.com/herodevs/cli/pull/561/files#diff-143d78eb344aee71bd9eff746283b5b3f8ac16dfe6be2091e29f678324100c00).

## Test Coverage

- Extended the successful callback test in [`test/commands/auth/login.test.ts`](https://github.com/herodevs/cli/pull/561/files#diff-adfa4f03a130fe55c6b273e14a2d45c8fd93cffc0449052d1e1417bd154caa3e) to assert that the browser response now returns a `302` to the static completion page, including the exact `Location` header and response completion checks in [the updated success-path assertion](https://github.com/herodevs/cli/pull/561/files#diff-adfa4f03a130fe55c6b273e14a2d45c8fd93cffc0449052d1e1417bd154caa3eR195-R198).
- Verified locally with `npx vitest run test/commands/auth/login.test.ts`.
