### PR TITLE
fix(cli): detect expired CI tokens locally

### DIFF
--- a/src/service/auth-token.svc.ts
+++ b/src/service/auth-token.svc.ts
@@ -1,5 +1,5 @@
 import { createConfStore, decryptValue, encryptValue } from './encrypted-store.svc.ts';
-import { decodeJwtPayload } from './jwt.svc.ts';
+import { isJwtExpired } from './jwt.svc.ts';
 import { debugLogger } from './log.svc.ts';
 
 export interface StoredTokens {
@@ -67,11 +67,5 @@ export async function clearStoredTokens() {
 }
 
 export function isAccessTokenExpired(token: string | undefined): boolean {
-  const payload = decodeJwtPayload(token) as { exp?: number } | undefined;
-  if (!payload?.exp) {
-    return true;
-  }
-
-  const now = Date.now() / 1000;
-  return now + TOKEN_SKEW_SECONDS >= payload.exp;
+  return isJwtExpired(token, TOKEN_SKEW_SECONDS) ?? true;
 }

--- a/src/service/ci-auth.svc.ts
+++ b/src/service/ci-auth.svc.ts
@@ -2,16 +2,20 @@ import { CITokenCommunicationError, exchangeCITokenForAccess } from '../api/ci-t
 import { ApiError } from '../api/errors.ts';
 import { config } from '../config/constants.ts';
 import { getCIToken, saveCIToken } from './ci-token.svc.ts';
+import { isJwtExpired } from './jwt.svc.ts';
 import { debugLogger } from './log.svc.ts';
 
 export type CITokenErrorCode =
   | 'CI_TOKEN_INVALID'
+  | 'CI_TOKEN_EXPIRED'
   | 'CI_TOKEN_REFRESH_FAILED'
   | 'CI_TOKEN_COMMUNICATION_FAILED'
   | 'CI_ORG_ID_REQUIRED';
 
 const CITOKEN_ERROR_MESSAGE =
   "CI token is invalid or expired. To provision a new CI token, run 'hd auth provision-ci-token' (after logging in with 'hd auth login').";
+const CITOKEN_EXPIRED_ERROR_MESSAGE =
+  'Your CI token has expired. To provision a new CI token, run hd auth provision-ci-token (after logging in with hd auth login).';
 const CITOKEN_COMMUNICATION_ERROR_MESSAGE =
   'There was an error communicating with the HeroDevs server while refreshing the CI token. Please verify server connectivity/configuration and try again.';
 
@@ -29,6 +33,10 @@ export async function requireCIAccessToken(): Promise<string> {
   const ciToken = getCIToken();
   if (!ciToken) {
     throw new CITokenError(CITOKEN_ERROR_MESSAGE, 'CI_TOKEN_INVALID');
+  }
+
+  if (isJwtExpired(ciToken)) {
+    throw new CITokenError(CITOKEN_EXPIRED_ERROR_MESSAGE, 'CI_TOKEN_EXPIRED');
   }
 
   try {

--- a/src/service/jwt.svc.ts
+++ b/src/service/jwt.svc.ts
@@ -19,3 +19,14 @@ export function decodeJwtPayload(token: string | undefined): Record<string, unkn
     return;
   }
 }
+
+export function isJwtExpired(token: string | undefined, skewSeconds = 30): boolean | undefined {
+  const payload = decodeJwtPayload(token);
+  const exp = payload?.exp;
+  if (typeof exp !== 'number') {
+    return;
+  }
+
+  const now = Date.now() / 1000;
+  return now + skewSeconds >= exp;
+}

--- a/test/service/ci-auth.svc.test.ts
+++ b/test/service/ci-auth.svc.test.ts
@@ -26,6 +26,14 @@ import { ApiError, INVALID_TOKEN_ERROR_CODE } from '../../src/api/errors.ts';
 import { requireCIAccessToken } from '../../src/service/ci-auth.svc.ts';
 import { getCIToken, saveCIToken } from '../../src/service/ci-token.svc.ts';
 
+function createTokenWithExp(offsetSeconds: number) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + offsetSeconds })).toString(
+    'base64url',
+  );
+  return `${header}.${payload}.signature`;
+}
+
 describe('ci-auth.svc', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -53,6 +61,43 @@ describe('ci-auth.svc', () => {
       code: 'CI_TOKEN_INVALID',
     });
     expect(ciTokenClient.exchangeCITokenForAccess).not.toHaveBeenCalled();
+  });
+
+  it('throws expired error without exchanging the CI token when JWT exp is expired', async () => {
+    (getCIToken as Mock).mockReturnValue(createTokenWithExp(-60));
+    const exchangeSpy = vi.spyOn(ciTokenClient, 'exchangeCITokenForAccess');
+
+    await expect(requireCIAccessToken()).rejects.toMatchObject({
+      name: 'CITokenError',
+      code: 'CI_TOKEN_EXPIRED',
+      message:
+        'Your CI token has expired. To provision a new CI token, run hd auth provision-ci-token (after logging in with hd auth login).',
+    });
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws expired error for env CI token without exchanging when JWT exp is expired', async () => {
+    const expiredToken = createTokenWithExp(-60);
+    mockConfig.ciTokenFromEnv = expiredToken;
+    (getCIToken as Mock).mockReturnValue(expiredToken);
+    const exchangeSpy = vi.spyOn(ciTokenClient, 'exchangeCITokenForAccess');
+
+    await expect(requireCIAccessToken()).rejects.toMatchObject({
+      name: 'CITokenError',
+      code: 'CI_TOKEN_EXPIRED',
+    });
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  });
+
+  it('exchanges the CI token when JWT exp is not expired', async () => {
+    (getCIToken as Mock).mockReturnValue(createTokenWithExp(120));
+    const exchangeSpy = vi.spyOn(ciTokenClient, 'exchangeCITokenForAccess').mockResolvedValue({
+      accessToken: 'access',
+      refreshToken: 'rotated-refresh',
+    });
+
+    await expect(requireCIAccessToken()).resolves.toBe('access');
+    expect(exchangeSpy).toHaveBeenCalledOnce();
   });
 
   it('throws refresh failure when exchange is explicitly rejected by the server', async () => {

--- a/test/service/jwt.svc.test.ts
+++ b/test/service/jwt.svc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { decodeJwtPayload } from '../../src/service/jwt.svc.ts';
+import { decodeJwtPayload, isJwtExpired } from '../../src/service/jwt.svc.ts';
 
 function createJwtToken(payload: unknown): string {
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
@@ -42,6 +42,26 @@ describe('jwt.svc', () => {
       expect(decodeJwtPayload(createJwtToken(['array-payload']))).toBeUndefined();
       expect(decodeJwtPayload(createJwtToken(123))).toBeUndefined();
       expect(decodeJwtPayload(createJwtToken(null))).toBeUndefined();
+    });
+  });
+
+  describe('isJwtExpired', () => {
+    it('returns true when the token exp is in the past', () => {
+      const token = createJwtToken({ exp: Math.floor(Date.now() / 1000) - 60 });
+
+      expect(isJwtExpired(token)).toBe(true);
+    });
+
+    it('returns false when the token exp is in the future beyond skew', () => {
+      const token = createJwtToken({ exp: Math.floor(Date.now() / 1000) + 120 });
+
+      expect(isJwtExpired(token)).toBe(false);
+    });
+
+    it('returns undefined when expiration cannot be determined', () => {
+      expect(isJwtExpired(createJwtToken({ sub: 'user-1' }))).toBeUndefined();
+      expect(isJwtExpired('not-a-jwt')).toBeUndefined();
+      expect(isJwtExpired(undefined)).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/neverendingsupport/data-and-integrations/issues/793

## What This Branch Does

This branch makes expired CI refresh tokens fail fast on the client before the CLI attempts any token exchange or scan request. It also adds a shared JWT expiration helper so CI token handling and OAuth access-token handling use the same expiration logic.

## CI Token Expiration Handling

- Adds the `CI_TOKEN_EXPIRED` branch to [`CITokenErrorCode`](https://github.com/herodevs/cli/pull/566/files#diff-0bbc4699dcabce352807fd73dc5e698247443b6a5fa3fe690aad601e98ed29a8R10) so expired CI tokens can be distinguished from invalid or server-rejected tokens.
- Adds [`CITOKEN_EXPIRED_ERROR_MESSAGE`](https://github.com/herodevs/cli/pull/566/files#diff-0bbc4699dcabce352807fd73dc5e698247443b6a5fa3fe690aad601e98ed29a8R17) with the explicit user-facing guidance for provisioning a new CI token.
- Updates [`requireCIAccessToken()`](https://github.com/herodevs/cli/pull/566/files#diff-0bbc4699dcabce352807fd73dc5e698247443b6a5fa3fe690aad601e98ed29a8R32) to check [`isJwtExpired()`](https://github.com/herodevs/cli/pull/566/files#diff-eaeb87e0ea45880cb708a5fba50a66b940650f38baae2b952c1abf1f59b04464R23) before exchanging the CI token, so an expired JWT fails locally without a network request.

## Shared JWT Expiration Utility

- Adds [`isJwtExpired()`](https://github.com/herodevs/cli/pull/566/files#diff-eaeb87e0ea45880cb708a5fba50a66b940650f38baae2b952c1abf1f59b04464R23) to centralize JWT `exp` parsing with skew support.
- Refactors [`isAccessTokenExpired()`](https://github.com/herodevs/cli/pull/566/files#diff-cc4172fcee59a7f2c80a6d50db4095a8067c31e09af94e52d235dcbc5c4f4170R69) to reuse [`isJwtExpired()`](https://github.com/herodevs/cli/pull/566/files#diff-eaeb87e0ea45880cb708a5fba50a66b940650f38baae2b952c1abf1f59b04464R23), preserving the existing behavior that indeterminate access tokens are treated as expired.

## Test Coverage

- Adds [`createTokenWithExp()`](https://github.com/herodevs/cli/pull/566/files#diff-961adf1f0190f0d7baad7a26fb905ca06acb5375e27fe0b71c5c72f5dca932d4R29) test support for generating JWT-shaped CI tokens with controlled expiration.
- Covers expired CI tokens in [`requireCIAccessToken()`](https://github.com/herodevs/cli/pull/566/files#diff-961adf1f0190f0d7baad7a26fb905ca06acb5375e27fe0b71c5c72f5dca932d4R66), including the exact message and the assertion that token exchange is not called.
- Covers env-provided expired CI tokens in [`requireCIAccessToken()`](https://github.com/herodevs/cli/pull/566/files#diff-961adf1f0190f0d7baad7a26fb905ca06acb5375e27fe0b71c5c72f5dca932d4R79), ensuring `HD_CI_CREDENTIAL` follows the same local expiration path.
- Covers the non-expired CI token path in [`requireCIAccessToken()`](https://github.com/herodevs/cli/pull/566/files#diff-961adf1f0190f0d7baad7a26fb905ca06acb5375e27fe0b71c5c72f5dca932d4R92), verifying token exchange still occurs when the JWT is valid.
- Adds direct tests for [`isJwtExpired()`](https://github.com/herodevs/cli/pull/566/files#diff-eddb5eb5f120d7c76133819fcb563b73a3ecc802ea08c81115458a0e73669d91R48), covering expired, valid, and indeterminate JWT payloads.
