### PR TITLE
feat: Add VEX Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pnpm-lock.yaml
 # Various CLI Output Files
 herodevs.report.json
 herodevs.sbom.json
+herodevs.openvex.json
 bom.json
 sbom.json
 cdx.json

--- a/README.md
+++ b/README.md
@@ -357,17 +357,22 @@ Download and filter the HeroDevs VEX statement
 ```
 USAGE
   $ hd vex [--json] [-f <value>] [-p <value>...] [-v <value>...] [--status
-    affected|not_affected|fixed|under_investigation...] [-s] [-o <value>]
+    affected|not_affected|fixed|under_investigation...] [-e <value>...] [-s] [-o <value>]
 
 FLAGS
-  -f, --file=<value>        Path to a CycloneDX or SPDX 2.3 SBOM; filters VEX entries to packages present in the SBOM
-  -o, --output=<value>      Save VEX statement to a custom path (defaults to herodevs.vex.json when not provided)
-  -p, --package=<value>...  Glob pattern matched against product PURLs (repeatable, e.g. --package "pkg:npm/lodash*").
-                            Keeps statements where any product matches.
-  -s, --save                Save VEX statement to herodevs.vex.json in the current directory
-  -v, --vuln=<value>...     Glob pattern matched against vulnerability IDs (repeatable, e.g. --vuln "CVE-2021-*")
-      --status=<option>...  Filter by VEX analysis status (repeatable)
-                            <options: affected|not_affected|fixed|under_investigation>
+  -e, --exclude-package=<value>...  Glob pattern matched against product PURLs to exclude (repeatable, e.g.
+                                    --exclude-package "pkg:npm/lodash*"). Removes statements where any product matches.
+  -f, --file=<value>                Path to a CycloneDX or SPDX 2.3 SBOM; filters VEX entries to packages present in the
+                                    SBOM
+  -o, --output=<value>              Save VEX statement to a custom path (defaults to herodevs.vex.json when not
+                                    provided)
+  -p, --package=<value>...          Glob pattern matched against product PURLs (repeatable, e.g. --package
+                                    "pkg:npm/lodash*"). Keeps statements where any product matches.
+  -s, --save                        Save VEX statement to herodevs.vex.json in the current directory
+  -v, --vuln=<value>...             Glob pattern matched against vulnerability IDs (repeatable, e.g. --vuln
+                                    "CVE-2021-*")
+      --status=<option>...          Filter by VEX analysis status (repeatable)
+                                    <options: affected|not_affected|fixed|under_investigation>
 
 GLOBAL FLAGS
   --json  Format output as json.
@@ -399,6 +404,10 @@ EXAMPLES
   Save filtered VEX to a file
 
     $ hd vex --file sbom.json --save
+
+  Exclude packages matching a PURL pattern
+
+    $ hd vex --exclude-package "pkg:npm/lodash*"
 
   Combine multiple filters (AND logic)
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ USAGE
 * [`hd tracker init`](#hd-tracker-init)
 * [`hd tracker run`](#hd-tracker-run)
 * [`hd update [CHANNEL]`](#hd-update-channel)
+* [`hd vex`](#hd-vex)
 
 ### `hd auth login`
 
@@ -177,10 +178,10 @@ USAGE
 FLAGS
   -c, --csv                 Output in CSV format
   -d, --directory=<value>   Directory to search
-  -e, --afterDate=<value>   [default: 2025-04-23] Start date (format: yyyy-MM-dd)
+  -e, --afterDate=<value>   [default: 2025-05-01] Start date (format: yyyy-MM-dd)
   -m, --months=<value>      [default: 12] The number of months of git history to review. Cannot be used along beforeDate
                             and afterDate
-  -s, --beforeDate=<value>  [default: 2026-04-23] End date (format: yyyy-MM-dd)
+  -s, --beforeDate=<value>  [default: 2026-05-01] End date (format: yyyy-MM-dd)
   -s, --save                Save the committers report as herodevs.committers.<output>
   -x, --exclude=<value>...  Path Exclusions (eg -x="./src/bin" -x="./dist")
       --json                Output to JSON format
@@ -336,7 +337,7 @@ EXAMPLES
 
   Update to a specific version:
 
-    $ hd update --version 2.0.6
+    $ hd update --version 1.0.0
 
   Interactively select version:
 
@@ -348,6 +349,63 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-update](https://github.com/oclif/plugin-update/blob/4.7.32/src/commands/update.ts)_
+
+### `hd vex`
+
+Download and filter the HeroDevs VEX statement
+
+```
+USAGE
+  $ hd vex [--json] [-f <value>] [-p <value>...] [-v <value>...] [--status
+    affected|not_affected|fixed|under_investigation...] [-s] [-o <value>]
+
+FLAGS
+  -f, --file=<value>        Path to a CycloneDX or SPDX 2.3 SBOM; filters VEX entries to packages present in the SBOM
+  -o, --output=<value>      Save VEX statement to a custom path (defaults to herodevs.vex.json when not provided)
+  -p, --package=<value>...  Glob pattern matched against product PURLs (repeatable, e.g. --package "pkg:npm/lodash*").
+                            Keeps statements where any product matches.
+  -s, --save                Save VEX statement to herodevs.vex.json in the current directory
+  -v, --vuln=<value>...     Glob pattern matched against vulnerability IDs (repeatable, e.g. --vuln "CVE-2021-*")
+      --status=<option>...  Filter by VEX analysis status (repeatable)
+                            <options: affected|not_affected|fixed|under_investigation>
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Download and filter the HeroDevs VEX statement
+
+EXAMPLES
+  Download the full HeroDevs VEX statement
+
+    $ hd vex
+
+  Filter to packages present in an SBOM
+
+    $ hd vex --file /path/to/sbom.json
+
+  Filter by vulnerability ID pattern
+
+    $ hd vex --vuln "CVE-2021-*"
+
+  Filter by package PURL pattern
+
+    $ hd vex --package "pkg:npm/express*"
+
+  Filter by status
+
+    $ hd vex --status not_affected
+
+  Save filtered VEX to a file
+
+    $ hd vex --file sbom.json --save
+
+  Combine multiple filters (AND logic)
+
+    $ hd vex --file sbom.json --vuln "CVE-*" --status affected
+```
+
+_See code: [src/commands/vex/index.ts](https://github.com/herodevs/cli/blob/v2.0.6/src/commands/vex/index.ts)_
 <!-- commandsstop -->
 
 ## CI/CD Usage

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ npm install -g @herodevs/cli
 $ hd COMMAND
 running command...
 $ hd (--version|-v)
-@herodevs/cli/2.0.6 darwin-arm64 node-v24.14.1
+@herodevs/cli/2.0.6 darwin-arm64 node-v22.15.1
 $ hd --help [COMMAND]
 USAGE
   $ hd COMMAND
@@ -178,10 +178,10 @@ USAGE
 FLAGS
   -c, --csv                 Output in CSV format
   -d, --directory=<value>   Directory to search
-  -e, --afterDate=<value>   [default: 2025-05-01] Start date (format: yyyy-MM-dd)
+  -e, --afterDate=<value>   [default: 2025-05-05] Start date (format: yyyy-MM-dd)
   -m, --months=<value>      [default: 12] The number of months of git history to review. Cannot be used along beforeDate
                             and afterDate
-  -s, --beforeDate=<value>  [default: 2026-05-01] End date (format: yyyy-MM-dd)
+  -s, --beforeDate=<value>  [default: 2026-05-05] End date (format: yyyy-MM-dd)
   -s, --save                Save the committers report as herodevs.committers.<output>
   -x, --exclude=<value>...  Path Exclusions (eg -x="./src/bin" -x="./dist")
       --json                Output to JSON format
@@ -364,11 +364,11 @@ FLAGS
                                     --exclude-package "pkg:npm/lodash*"). Removes statements where any product matches.
   -f, --file=<value>                Path to a CycloneDX or SPDX 2.3 SBOM; filters VEX entries to packages present in the
                                     SBOM
-  -o, --output=<value>              Save VEX statement to a custom path (defaults to herodevs.vex.json when not
+  -o, --output=<value>              Save VEX statement to a custom path (defaults to herodevs.openvex.json when not
                                     provided)
   -p, --package=<value>...          Glob pattern matched against product PURLs (repeatable, e.g. --package
                                     "pkg:npm/lodash*"). Keeps statements where any product matches.
-  -s, --save                        Save VEX statement to herodevs.vex.json in the current directory
+  -s, --save                        Save VEX statement to herodevs.openvex.json in the current directory
   -v, --vuln=<value>...             Glob pattern matched against vulnerability IDs (repeatable, e.g. --vuln
                                     "CVE-2021-*")
       --status=<option>...          Filter by VEX analysis status (repeatable)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ npm install -g @herodevs/cli
 $ hd COMMAND
 running command...
 $ hd (--version|-v)
-@herodevs/cli/2.0.6 darwin-arm64 node-v22.15.1
+@herodevs/cli/2.0.6 darwin-arm64 node-v24.15.0
 $ hd --help [COMMAND]
 USAGE
   $ hd COMMAND
@@ -337,7 +337,7 @@ EXAMPLES
 
   Update to a specific version:
 
-    $ hd update --version 1.0.0
+    $ hd update --version 2.0.6
 
   Interactively select version:
 

--- a/src/commands/vex/index.ts
+++ b/src/commands/vex/index.ts
@@ -1,0 +1,148 @@
+import { Command, Flags } from '@oclif/core';
+import { filenamePrefix } from '../../config/constants.ts';
+import { track } from '../../service/analytics.svc.ts';
+import { readSbomFromFile, saveArtifactToFile } from '../../service/file.svc.ts';
+import { getErrorMessage } from '../../service/log.svc.ts';
+import { type OpenVexDocument, applyVexFilters, fetchVexStatement } from '../../service/vex.svc.ts';
+
+export default class Vex extends Command {
+  static override description = 'Download and filter the HeroDevs VEX statement';
+  static enableJsonFlag = true;
+  static override examples = [
+    {
+      description: 'Download the full HeroDevs VEX statement',
+      command: '<%= config.bin %> <%= command.id %>',
+    },
+    {
+      description: 'Filter to packages present in an SBOM',
+      command: '<%= config.bin %> <%= command.id %> --file /path/to/sbom.json',
+    },
+    {
+      description: 'Filter by vulnerability ID pattern',
+      command: '<%= config.bin %> <%= command.id %> --vuln "CVE-2021-*"',
+    },
+    {
+      description: 'Filter by package PURL pattern',
+      command: '<%= config.bin %> <%= command.id %> --package "pkg:npm/express*"',
+    },
+    {
+      description: 'Filter by status',
+      command: '<%= config.bin %> <%= command.id %> --status not_affected',
+    },
+    {
+      description: 'Save filtered VEX to a file',
+      command: '<%= config.bin %> <%= command.id %> --file sbom.json --save',
+    },
+    {
+      description: 'Combine multiple filters (AND logic)',
+      command: '<%= config.bin %> <%= command.id %> --file sbom.json --vuln "CVE-*" --status affected',
+    },
+  ];
+
+  static override flags = {
+    file: Flags.string({
+      char: 'f',
+      description: 'Path to a CycloneDX or SPDX 2.3 SBOM; filters VEX entries to packages present in the SBOM',
+    }),
+    package: Flags.string({
+      char: 'p',
+      description:
+        'Glob pattern matched against product PURLs (repeatable, e.g. --package "pkg:npm/lodash*"). Keeps statements where any product matches.',
+      multiple: true,
+    }),
+    vuln: Flags.string({
+      char: 'v',
+      description: 'Glob pattern matched against vulnerability IDs (repeatable, e.g. --vuln "CVE-2021-*")',
+      multiple: true,
+    }),
+    status: Flags.string({
+      description: 'Filter by VEX analysis status (repeatable)',
+      multiple: true,
+      options: ['affected', 'not_affected', 'fixed', 'under_investigation'],
+    }),
+    save: Flags.boolean({
+      char: 's',
+      default: false,
+      description: `Save VEX statement to ${filenamePrefix}.vex.json in the current directory`,
+    }),
+    output: Flags.string({
+      char: 'o',
+      description: `Save VEX statement to a custom path (defaults to ${filenamePrefix}.vex.json when not provided)`,
+    }),
+  };
+
+  public async run(): Promise<OpenVexDocument> {
+    const { flags } = await this.parse(Vex);
+
+    track('CLI VEX Download Started', (context) => ({
+      command: context.command,
+      command_flags: context.command_flags,
+    }));
+
+    let vex: OpenVexDocument;
+    try {
+      vex = await fetchVexStatement();
+    } catch (error) {
+      const message = getErrorMessage(error);
+      track('CLI VEX Download Failed', () => ({ error: message }));
+      this.error(`Failed to fetch VEX statement. ${message}`);
+    }
+
+    const hasFilters = flags.file || flags.package?.length || flags.vuln?.length || flags.status?.length;
+
+    if (hasFilters) {
+      const sbom = flags.file ? this.loadSbom(flags.file) : undefined;
+      vex = applyVexFilters(vex, {
+        sbom,
+        packagePatterns: flags.package,
+        vulnPatterns: flags.vuln,
+        statuses: flags.status,
+      });
+    }
+
+    track('CLI VEX Download Completed', (context) => ({
+      command: context.command,
+      command_flags: context.command_flags,
+      statement_count: vex.statements.length,
+      filtered: Boolean(hasFilters),
+    }));
+
+    let outputPath = flags.output;
+    if (flags.output && !flags.save) {
+      this.warn('--output requires --save to write the file. Run again with --save to create the file.');
+      outputPath = undefined;
+    }
+
+    const shouldSave = flags.save;
+    if (shouldSave) {
+      const savedPath = this.saveVex(vex, outputPath);
+      this.log(`VEX statement saved to ${savedPath}`);
+    }
+
+    if (!this.jsonEnabled()) {
+      this.log(JSON.stringify(vex, null, 2));
+    }
+
+    return vex;
+  }
+
+  private loadSbom(filePath: string) {
+    try {
+      return readSbomFromFile(filePath);
+    } catch (error) {
+      const message = getErrorMessage(error);
+      track('CLI Error Encountered', () => ({ error: message }));
+      this.error(message);
+    }
+  }
+
+  private saveVex(vex: OpenVexDocument, outputPath?: string): string {
+    try {
+      return saveArtifactToFile(process.cwd(), { kind: 'vex', payload: vex, outputPath });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      track('CLI Error Encountered', () => ({ error: message }));
+      this.error(message);
+    }
+  }
+}

--- a/src/commands/vex/index.ts
+++ b/src/commands/vex/index.ts
@@ -34,6 +34,10 @@ export default class Vex extends Command {
       command: '<%= config.bin %> <%= command.id %> --file sbom.json --save',
     },
     {
+      description: 'Exclude packages matching a PURL pattern',
+      command: '<%= config.bin %> <%= command.id %> --exclude-package "pkg:npm/lodash*"',
+    },
+    {
       description: 'Combine multiple filters (AND logic)',
       command: '<%= config.bin %> <%= command.id %> --file sbom.json --vuln "CVE-*" --status affected',
     },
@@ -59,6 +63,12 @@ export default class Vex extends Command {
       description: 'Filter by VEX analysis status (repeatable)',
       multiple: true,
       options: ['affected', 'not_affected', 'fixed', 'under_investigation'],
+    }),
+    'exclude-package': Flags.string({
+      char: 'e',
+      description:
+        'Glob pattern matched against product PURLs to exclude (repeatable, e.g. --exclude-package "pkg:npm/lodash*"). Removes statements where any product matches.',
+      multiple: true,
     }),
     save: Flags.boolean({
       char: 's',
@@ -88,7 +98,12 @@ export default class Vex extends Command {
       this.error(`Failed to fetch VEX statement. ${message}`);
     }
 
-    const hasFilters = flags.file || flags.package?.length || flags.vuln?.length || flags.status?.length;
+    const hasFilters =
+      flags.file ||
+      flags.package?.length ||
+      flags.vuln?.length ||
+      flags.status?.length ||
+      flags['exclude-package']?.length;
 
     if (hasFilters) {
       const sbom = flags.file ? this.loadSbom(flags.file) : undefined;
@@ -97,6 +112,7 @@ export default class Vex extends Command {
         packagePatterns: flags.package,
         vulnPatterns: flags.vuln,
         statuses: flags.status,
+        excludePackagePatterns: flags['exclude-package'],
       });
     }
 

--- a/src/commands/vex/index.ts
+++ b/src/commands/vex/index.ts
@@ -3,7 +3,7 @@ import { filenamePrefix } from '../../config/constants.ts';
 import { track } from '../../service/analytics.svc.ts';
 import { readSbomFromFile, saveArtifactToFile } from '../../service/file.svc.ts';
 import { getErrorMessage } from '../../service/log.svc.ts';
-import { type OpenVexDocument, applyVexFilters, fetchVexStatement } from '../../service/vex.svc.ts';
+import { applyVexFilters, fetchVexStatement, type OpenVexDocument } from '../../service/vex.svc.ts';
 
 export default class Vex extends Command {
   static override description = 'Download and filter the HeroDevs VEX statement';

--- a/src/commands/vex/index.ts
+++ b/src/commands/vex/index.ts
@@ -73,11 +73,11 @@ export default class Vex extends Command {
     save: Flags.boolean({
       char: 's',
       default: false,
-      description: `Save VEX statement to ${filenamePrefix}.vex.json in the current directory`,
+      description: `Save VEX statement to ${filenamePrefix}.openvex.json in the current directory`,
     }),
     output: Flags.string({
       char: 'o',
-      description: `Save VEX statement to a custom path (defaults to ${filenamePrefix}.vex.json when not provided)`,
+      description: `Save VEX statement to a custom path (defaults to ${filenamePrefix}.openvex.json when not provided)`,
     }),
   };
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -35,6 +35,7 @@ export const config = {
   graphqlPath: process.env.GRAPHQL_PATH || '/graphql',
   analyticsUrl: process.env.ANALYTICS_URL || 'https://apps.herodevs.com/api/eol/track',
   eolLogInUrl: process.env.EOL_LOG_IN_URL || 'https://apps.herodevs.com/eol/cli-logged-in',
+  vexStatementsUrl: process.env.VEX_STATEMENTS_URL || 'https://apps.herodevs.com/api/ontology/vex/statements',
   concurrentPageRequests,
   pageSize,
   ciTokenFromEnv: process.env.HD_CI_CREDENTIAL?.trim() || undefined,

--- a/src/service/file.svc.ts
+++ b/src/service/file.svc.ts
@@ -129,17 +129,19 @@ export function validateDirectory(dirPath: string): void {
   }
 }
 
-type SaveArtifactKind = 'sbom' | 'sbomTrimmed' | 'report';
+type SaveArtifactKind = 'sbom' | 'sbomTrimmed' | 'report' | 'vex';
 
 type SaveArtifactRequest =
   | { kind: 'sbom'; payload: CdxBom; outputPath?: string }
   | { kind: 'sbomTrimmed'; payload: CdxBom }
-  | { kind: 'report'; payload: EolReport; outputPath?: string };
+  | { kind: 'report'; payload: EolReport; outputPath?: string }
+  | { kind: 'vex'; payload: object; outputPath?: string };
 
 const artifactFilenames: Record<SaveArtifactKind, string> = {
   sbom: `${filenamePrefix}.sbom.json`,
   sbomTrimmed: `${filenamePrefix}.sbom-trimmed.json`,
   report: `${filenamePrefix}.report.json`,
+  vex: `${filenamePrefix}.openvex.json`,
 };
 
 /**

--- a/src/service/vex.svc.ts
+++ b/src/service/vex.svc.ts
@@ -110,6 +110,16 @@ export function filterByStatus(vex: OpenVexDocument, statuses: string[]): OpenVe
   return { ...vex, statements: filtered };
 }
 
+export function excludeByPackagePatterns(vex: OpenVexDocument, patterns: string[]): OpenVexDocument {
+  if (patterns.length === 0) return vex;
+
+  const filtered = vex.statements.filter(
+    (stmt) => !stmt.products.some((product) => matchesAnyPattern(product['@id'], patterns)),
+  );
+
+  return { ...vex, statements: filtered };
+}
+
 export function applyVexFilters(
   vex: OpenVexDocument,
   filters: {
@@ -117,6 +127,7 @@ export function applyVexFilters(
     packagePatterns?: string[];
     vulnPatterns?: string[];
     statuses?: string[];
+    excludePackagePatterns?: string[];
   },
 ): OpenVexDocument {
   let result = vex;
@@ -124,5 +135,6 @@ export function applyVexFilters(
   if (filters.packagePatterns?.length) result = filterByPackagePatterns(result, filters.packagePatterns);
   if (filters.vulnPatterns?.length) result = filterByVulnPatterns(result, filters.vulnPatterns);
   if (filters.statuses?.length) result = filterByStatus(result, filters.statuses);
+  if (filters.excludePackagePatterns?.length) result = excludeByPackagePatterns(result, filters.excludePackagePatterns);
   return result;
 }

--- a/src/service/vex.svc.ts
+++ b/src/service/vex.svc.ts
@@ -1,0 +1,128 @@
+import type { CdxBom } from '@herodevs/eol-shared';
+import { extractPurlsFromCdxBom } from '@herodevs/eol-shared';
+import { PackageURL } from 'packageurl-js';
+import { config } from '../config/constants.ts';
+
+export interface VexProduct {
+  '@id': string;
+  subcomponents?: Array<{ '@id': string }>;
+}
+
+export interface VexVulnerability {
+  '@id'?: string;
+  name: string;
+  aliases?: string[];
+  description?: string;
+}
+
+export interface VexStatement {
+  vulnerability: VexVulnerability;
+  products: VexProduct[];
+  status: 'not_affected' | 'affected' | 'fixed' | 'under_investigation';
+  justification?: string;
+  impact_statement?: string;
+  action_statement?: string;
+  action_statement_timestamp?: string;
+  timestamp?: string;
+}
+
+export interface OpenVexDocument {
+  '@context': string;
+  '@id': string;
+  author: string;
+  version: number;
+  timestamp?: string;
+  last_updated?: string;
+  tooling?: string;
+  statements: VexStatement[];
+}
+
+export async function fetchVexStatement(): Promise<OpenVexDocument> {
+  const response = await fetch(config.vexStatementsUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch VEX statement: HTTP ${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<OpenVexDocument>;
+}
+
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+function matchesAnyPattern(value: string, patterns: string[]): boolean {
+  return patterns.some((p) => globToRegex(p).test(value));
+}
+
+function normalizePurl(purl: string): string | null {
+  try {
+    const parsed = PackageURL.fromString(purl);
+    const ns = parsed.namespace ? `${parsed.namespace}/` : '';
+    const ver = parsed.version ? `@${parsed.version}` : '';
+    return `pkg:${parsed.type}/${ns}${parsed.name}${ver}`.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function filterByComponents(vex: OpenVexDocument, sbom: CdxBom): OpenVexDocument {
+  const normalizePurls = new Set(
+    extractPurlsFromCdxBom(sbom)
+      .map(normalizePurl)
+      .filter((b): b is string => b !== null),
+  );
+
+  if (normalizePurls.size === 0) return vex;
+
+  const filtered = vex.statements.filter((stmt) =>
+    stmt.products.some((product) => {
+      const base = normalizePurl(product['@id']);
+      return base !== null && normalizePurls.has(base);
+    }),
+  );
+
+  return { ...vex, statements: filtered };
+}
+
+export function filterByPackagePatterns(vex: OpenVexDocument, patterns: string[]): OpenVexDocument {
+  if (patterns.length === 0) return vex;
+
+  const filtered = vex.statements.filter((stmt) =>
+    stmt.products.some((product) => matchesAnyPattern(product['@id'], patterns)),
+  );
+
+  return { ...vex, statements: filtered };
+}
+
+export function filterByVulnPatterns(vex: OpenVexDocument, patterns: string[]): OpenVexDocument {
+  if (patterns.length === 0) return vex;
+
+  const filtered = vex.statements.filter((stmt) => matchesAnyPattern(stmt.vulnerability.name, patterns));
+
+  return { ...vex, statements: filtered };
+}
+
+export function filterByStatus(vex: OpenVexDocument, statuses: string[]): OpenVexDocument {
+  if (statuses.length === 0) return vex;
+
+  const filtered = vex.statements.filter((stmt) => statuses.includes(stmt.status));
+
+  return { ...vex, statements: filtered };
+}
+
+export function applyVexFilters(
+  vex: OpenVexDocument,
+  filters: {
+    sbom?: CdxBom;
+    packagePatterns?: string[];
+    vulnPatterns?: string[];
+    statuses?: string[];
+  },
+): OpenVexDocument {
+  let result = vex;
+  if (filters.sbom) result = filterByComponents(result, filters.sbom);
+  if (filters.packagePatterns?.length) result = filterByPackagePatterns(result, filters.packagePatterns);
+  if (filters.vulnPatterns?.length) result = filterByVulnPatterns(result, filters.vulnPatterns);
+  if (filters.statuses?.length) result = filterByStatus(result, filters.statuses);
+  return result;
+}

--- a/src/service/vex.svc.ts
+++ b/src/service/vex.svc.ts
@@ -46,7 +46,10 @@ export async function fetchVexStatement(): Promise<OpenVexDocument> {
 }
 
 function globToRegex(pattern: string): RegExp {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
   return new RegExp(`^${escaped}$`, 'i');
 }
 

--- a/src/service/vex.svc.ts
+++ b/src/service/vex.svc.ts
@@ -74,12 +74,15 @@ export function filterByComponents(vex: OpenVexDocument, sbom: CdxBom): OpenVexD
 
   if (normalizePurls.size === 0) return vex;
 
-  const filtered = vex.statements.filter((stmt) =>
-    stmt.products.some((product) => {
-      const base = normalizePurl(product['@id']);
-      return base !== null && normalizePurls.has(base);
-    }),
-  );
+  const filtered = vex.statements
+    .map((stmt) => ({
+      ...stmt,
+      products: stmt.products.filter((product) => {
+        const base = normalizePurl(product['@id']);
+        return base !== null && normalizePurls.has(base);
+      }),
+    }))
+    .filter((stmt) => stmt.products.length > 0);
 
   return { ...vex, statements: filtered };
 }
@@ -87,9 +90,12 @@ export function filterByComponents(vex: OpenVexDocument, sbom: CdxBom): OpenVexD
 export function filterByPackagePatterns(vex: OpenVexDocument, patterns: string[]): OpenVexDocument {
   if (patterns.length === 0) return vex;
 
-  const filtered = vex.statements.filter((stmt) =>
-    stmt.products.some((product) => matchesAnyPattern(product['@id'], patterns)),
-  );
+  const filtered = vex.statements
+    .map((stmt) => ({
+      ...stmt,
+      products: stmt.products.filter((product) => matchesAnyPattern(product['@id'], patterns)),
+    }))
+    .filter((stmt) => stmt.products.length > 0);
 
   return { ...vex, statements: filtered };
 }
@@ -113,9 +119,12 @@ export function filterByStatus(vex: OpenVexDocument, statuses: string[]): OpenVe
 export function excludeByPackagePatterns(vex: OpenVexDocument, patterns: string[]): OpenVexDocument {
   if (patterns.length === 0) return vex;
 
-  const filtered = vex.statements.filter(
-    (stmt) => !stmt.products.some((product) => matchesAnyPattern(product['@id'], patterns)),
-  );
+  const filtered = vex.statements
+    .map((stmt) => ({
+      ...stmt,
+      products: stmt.products.filter((product) => !matchesAnyPattern(product['@id'], patterns)),
+    }))
+    .filter((stmt) => stmt.products.length > 0);
 
   return { ...vex, statements: filtered };
 }

--- a/test/commands/vex/index.test.ts
+++ b/test/commands/vex/index.test.ts
@@ -1,0 +1,323 @@
+import type { CdxBom } from '@herodevs/eol-shared';
+import type { Config } from '@oclif/core';
+import { vi } from 'vitest';
+import type { OpenVexDocument } from '../../../src/service/vex.svc.ts';
+
+const { fetchVexStatementMock, applyVexFiltersMock, trackMock, readSbomFromFileMock, saveArtifactToFileMock } =
+  vi.hoisted(() => ({
+    fetchVexStatementMock: vi.fn(),
+    applyVexFiltersMock: vi.fn(),
+    trackMock: vi.fn(),
+    readSbomFromFileMock: vi.fn(),
+    saveArtifactToFileMock: vi.fn(),
+  }));
+
+vi.mock('../../../src/service/vex.svc.ts', () => ({
+  fetchVexStatement: fetchVexStatementMock,
+  applyVexFilters: applyVexFiltersMock,
+}));
+
+vi.mock('../../../src/service/file.svc.ts', () => ({
+  readSbomFromFile: readSbomFromFileMock,
+  saveArtifactToFile: saveArtifactToFileMock,
+}));
+
+vi.mock('../../../src/service/analytics.svc.ts', () => ({
+  track: trackMock,
+}));
+
+import Vex from '../../../src/commands/vex/index.ts';
+
+const sampleVex: OpenVexDocument = {
+  '@context': 'https://openvex.dev/ns/v0.2.0',
+  '@id': 'https://openvex.dev/docs/public/vex-test',
+  author: 'HeroDevs',
+  version: 1,
+  statements: [
+    {
+      vulnerability: { name: 'CVE-2021-23337' },
+      products: [{ '@id': 'pkg:npm/lodash@4.17.20' }],
+      status: 'not_affected',
+    },
+  ],
+};
+
+const filteredVex: OpenVexDocument = {
+  ...sampleVex,
+  statements: [],
+};
+
+type VexCommandInternals = {
+  parse: (...args: unknown[]) => Promise<{ flags: Record<string, unknown> }>;
+  log: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string | Error) => never;
+  jsonEnabled: () => boolean;
+  run: () => Promise<OpenVexDocument>;
+};
+
+function createCommand(): VexCommandInternals {
+  return new Vex([], {} as Config) as unknown as VexCommandInternals;
+}
+
+describe('vex command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchVexStatementMock.mockResolvedValue(sampleVex);
+    applyVexFiltersMock.mockImplementation((vex: OpenVexDocument) => vex);
+    saveArtifactToFileMock.mockReturnValue('/cwd/herodevs.openvex.json');
+  });
+
+  describe('default behavior (no flags)', () => {
+    it('fetches VEX and logs it as formatted JSON to stdout', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });
+      const logSpy = vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      const result = await command.run();
+
+      expect(fetchVexStatementMock).toHaveBeenCalledOnce();
+      expect(applyVexFiltersMock).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(sampleVex, null, 2));
+      expect(result).toEqual(sampleVex);
+    });
+
+    it('returns the VEX document', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(true);
+
+      const result = await command.run();
+
+      expect(result).toEqual(sampleVex);
+    });
+
+    it('skips logging JSON when --json flag is active', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });
+      const logSpy = vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(true);
+
+      await command.run();
+
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('filtering', () => {
+    it('reads SBOM and passes it to applyVexFilters when --file is provided', async () => {
+      const mockSbom = { components: [] } as unknown as CdxBom;
+      readSbomFromFileMock.mockReturnValue(mockSbom);
+
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { file: '/path/to/sbom.json' } });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(readSbomFromFileMock).toHaveBeenCalledWith('/path/to/sbom.json');
+      expect(applyVexFiltersMock).toHaveBeenCalledWith(sampleVex, expect.objectContaining({ sbom: mockSbom }));
+    });
+
+    it('passes package patterns to applyVexFilters', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { package: ['pkg:npm/lodash*', 'pkg:npm/express*'] } });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(applyVexFiltersMock).toHaveBeenCalledWith(
+        sampleVex,
+        expect.objectContaining({ packagePatterns: ['pkg:npm/lodash*', 'pkg:npm/express*'] }),
+      );
+    });
+
+    it('passes vuln patterns to applyVexFilters', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { vuln: ['CVE-2021-*'] } });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(applyVexFiltersMock).toHaveBeenCalledWith(
+        sampleVex,
+        expect.objectContaining({ vulnPatterns: ['CVE-2021-*'] }),
+      );
+    });
+
+    it('passes status list to applyVexFilters', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { status: ['not_affected', 'fixed'] } });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(applyVexFiltersMock).toHaveBeenCalledWith(
+        sampleVex,
+        expect.objectContaining({ statuses: ['not_affected', 'fixed'] }),
+      );
+    });
+
+    it('skips applyVexFilters entirely when no filters are provided', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(applyVexFiltersMock).not.toHaveBeenCalled();
+    });
+
+    it('logs the filtered VEX, not the original', async () => {
+      applyVexFiltersMock.mockReturnValue(filteredVex);
+
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { status: ['affected'] } });
+      const logSpy = vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      const result = await command.run();
+
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(filteredVex, null, 2));
+      expect(result).toEqual(filteredVex);
+    });
+  });
+
+  describe('saving', () => {
+    it('saves to default path when --save is provided', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { save: true } });
+      const logSpy = vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(saveArtifactToFileMock).toHaveBeenCalledWith(process.cwd(), {
+        kind: 'vex',
+        payload: sampleVex,
+        outputPath: undefined,
+      });
+      expect(logSpy).toHaveBeenCalledWith('VEX statement saved to /cwd/herodevs.openvex.json');
+    });
+
+    it('saves to custom path when --save and --output are both provided', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { save: true, output: './reports/my-vex.json' } });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(saveArtifactToFileMock).toHaveBeenCalledWith(process.cwd(), {
+        kind: 'vex',
+        payload: sampleVex,
+        outputPath: './reports/my-vex.json',
+      });
+    });
+
+    it('does not save when no save flags are provided', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(saveArtifactToFileMock).not.toHaveBeenCalled();
+    });
+
+    it('warns and does not save when --output is given without --save', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { output: './my-vex.json' } });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(command, 'warn').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('--output requires --save'));
+      expect(saveArtifactToFileMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('errors with a descriptive message when fetch fails', async () => {
+      fetchVexStatementMock.mockRejectedValue(new Error('Network error'));
+
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });
+      vi.spyOn(command, 'error').mockImplementation((msg: string | Error) => {
+        throw new Error(typeof msg === 'string' ? msg : msg.message);
+      });
+
+      await expect(command.run()).rejects.toThrow('Failed to fetch VEX statement. Network error');
+    });
+
+    it('errors when SBOM file cannot be read', async () => {
+      readSbomFromFileMock.mockImplementation(() => {
+        throw new Error('SBOM file not found: /missing/sbom.json');
+      });
+
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { file: '/missing/sbom.json' } });
+      vi.spyOn(command, 'error').mockImplementation((msg: string | Error) => {
+        throw new Error(typeof msg === 'string' ? msg : msg.message);
+      });
+
+      await expect(command.run()).rejects.toThrow('SBOM file not found: /missing/sbom.json');
+    });
+  });
+
+  describe('analytics', () => {
+    it('tracks download started and completed events', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      const events = trackMock.mock.calls.map(([event]: [string]) => event);
+      expect(events).toContain('CLI VEX Download Started');
+      expect(events).toContain('CLI VEX Download Completed');
+    });
+
+    it('tracks statement count and filtered flag on completion', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { vuln: ['CVE-*'] } });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      const completedCall = trackMock.mock.calls.find(([event]: [string]) => event === 'CLI VEX Download Completed');
+      expect(completedCall).toBeDefined();
+      const getProperties = completedCall?.[1] as (ctx: Record<string, unknown>) => Record<string, unknown>;
+      const properties = getProperties({ command: 'vex', command_flags: '--vuln CVE-*' });
+      expect(properties.statement_count).toEqual(expect.any(Number));
+      expect(properties.filtered).toBe(true);
+    });
+
+    it('tracks download failed event on fetch error', async () => {
+      fetchVexStatementMock.mockRejectedValue(new Error('timeout'));
+
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });
+      vi.spyOn(command, 'error').mockImplementation(() => {
+        throw new Error('error');
+      });
+
+      await command.run().catch(() => {});
+
+      const events = trackMock.mock.calls.map(([event]: [string]) => event);
+      expect(events).toContain('CLI VEX Download Failed');
+    });
+  });
+});

--- a/test/commands/vex/index.test.ts
+++ b/test/commands/vex/index.test.ts
@@ -164,6 +164,52 @@ describe('vex command', () => {
       );
     });
 
+    it('passes exclude-package patterns to applyVexFilters', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({
+        flags: { 'exclude-package': ['pkg:npm/lodash*', 'pkg:npm/express*'] },
+      });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(applyVexFiltersMock).toHaveBeenCalledWith(
+        sampleVex,
+        expect.objectContaining({ excludePackagePatterns: ['pkg:npm/lodash*', 'pkg:npm/express*'] }),
+      );
+    });
+
+    it('triggers filtering when only --exclude-package is provided', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({ flags: { 'exclude-package': ['pkg:npm/lodash*'] } });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(applyVexFiltersMock).toHaveBeenCalledOnce();
+    });
+
+    it('combines --exclude-package with --package (AND logic)', async () => {
+      const command = createCommand();
+      vi.spyOn(command, 'parse').mockResolvedValue({
+        flags: { package: ['pkg:npm/lodash*'], 'exclude-package': ['pkg:npm/lodash@4.17.20'] },
+      });
+      vi.spyOn(command, 'log').mockImplementation(() => {});
+      vi.spyOn(command, 'jsonEnabled').mockReturnValue(false);
+
+      await command.run();
+
+      expect(applyVexFiltersMock).toHaveBeenCalledWith(
+        sampleVex,
+        expect.objectContaining({
+          packagePatterns: ['pkg:npm/lodash*'],
+          excludePackagePatterns: ['pkg:npm/lodash@4.17.20'],
+        }),
+      );
+    });
+
     it('skips applyVexFilters entirely when no filters are provided', async () => {
       const command = createCommand();
       vi.spyOn(command, 'parse').mockResolvedValue({ flags: {} });

--- a/test/commands/vex/vex.test.ts
+++ b/test/commands/vex/vex.test.ts
@@ -330,7 +330,7 @@ describe('vex command', () => {
 
       await command.run();
 
-      const events = trackMock.mock.calls.map(([event]: [string]) => event);
+      const events = trackMock.mock.calls.map((event) => event[0]);
       expect(events).toContain('CLI VEX Download Started');
       expect(events).toContain('CLI VEX Download Completed');
     });
@@ -343,7 +343,7 @@ describe('vex command', () => {
 
       await command.run();
 
-      const completedCall = trackMock.mock.calls.find(([event]: [string]) => event === 'CLI VEX Download Completed');
+      const completedCall = trackMock.mock.calls.find((event) => event[0] === 'CLI VEX Download Completed');
       expect(completedCall).toBeDefined();
       const getProperties = completedCall?.[1] as (ctx: Record<string, unknown>) => Record<string, unknown>;
       const properties = getProperties({ command: 'vex', command_flags: '--vuln CVE-*' });
@@ -362,7 +362,7 @@ describe('vex command', () => {
 
       await command.run().catch(() => {});
 
-      const events = trackMock.mock.calls.map(([event]: [string]) => event);
+      const events = trackMock.mock.calls.map((event) => event[0]);
       expect(events).toContain('CLI VEX Download Failed');
     });
   });

--- a/test/service/vex.svc.test.ts
+++ b/test/service/vex.svc.test.ts
@@ -1,0 +1,326 @@
+import { vi } from 'vitest';
+
+const { extractPurlsFromCdxBomMock } = vi.hoisted(() => ({
+  extractPurlsFromCdxBomMock: vi.fn(),
+}));
+
+vi.mock('@herodevs/eol-shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@herodevs/eol-shared')>();
+  return { ...actual, extractPurlsFromCdxBom: extractPurlsFromCdxBomMock };
+});
+
+vi.mock('../../src/config/constants.ts', async (importOriginal) => importOriginal());
+
+import type { CdxBom } from '@herodevs/eol-shared';
+import { config } from '../../src/config/constants.ts';
+import {
+  applyVexFilters,
+  fetchVexStatement,
+  filterByComponents,
+  filterByPackagePatterns,
+  filterByStatus,
+  filterByVulnPatterns,
+  type OpenVexDocument,
+} from '../../src/service/vex.svc.ts';
+import { FetchMock } from '../utils/mocks/fetch.mock.ts';
+
+const mockVex: OpenVexDocument = {
+  '@context': 'https://openvex.dev/ns/v0.2.0',
+  '@id': 'https://openvex.dev/docs/public/vex-test',
+  author: 'HeroDevs',
+  version: 1,
+  statements: [
+    {
+      vulnerability: { name: 'CVE-2018-20676', aliases: ['GHSA-3mgp-fx93-9xv5'] },
+      products: [{ '@id': 'pkg:npm/bootstrap@3.0.0' }, { '@id': 'pkg:npm/bootstrap@3.1.0' }],
+      status: 'not_affected',
+      justification: 'component_not_present',
+    },
+    {
+      vulnerability: { name: 'CVE-2021-23337' },
+      products: [{ '@id': 'pkg:npm/lodash@4.17.20' }],
+      status: 'affected',
+    },
+    {
+      vulnerability: { name: 'CVE-2022-31129' },
+      products: [{ '@id': 'pkg:npm/moment@2.29.3' }],
+      status: 'fixed',
+    },
+    {
+      vulnerability: { name: 'CVE-2020-8203' },
+      products: [{ '@id': 'pkg:npm/lodash@4.17.15' }],
+      status: 'under_investigation',
+    },
+  ],
+};
+
+const mockSbom = {} as unknown as CdxBom;
+
+describe('vex.svc', () => {
+  describe('fetchVexStatement', () => {
+    let fetchMock: FetchMock;
+
+    beforeEach(() => {
+      fetchMock = new FetchMock();
+    });
+
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('returns parsed OpenVEX document on success', async () => {
+      fetchMock.push({
+        ok: true,
+        status: 200,
+        async json() {
+          return mockVex;
+        },
+      } as unknown as Response);
+
+      const result = await fetchVexStatement();
+
+      expect(result).toEqual(mockVex);
+    });
+
+    it('throws with status details on non-200 response', async () => {
+      fetchMock.push({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      } as unknown as Response);
+
+      await expect(fetchVexStatement()).rejects.toThrow(
+        'Failed to fetch VEX statement: HTTP 503 Service Unavailable',
+      );
+    });
+
+    it('fetches from the configured VEX statements URL', async () => {
+      fetchMock.push({
+        ok: true,
+        status: 200,
+        async json() {
+          return mockVex;
+        },
+      } as unknown as Response);
+
+      await fetchVexStatement();
+
+      const [call] = fetchMock.getCalls();
+      expect(call.input).toBe(config.vexStatementsUrl);
+    });
+  });
+
+  describe('filterByComponents', () => {
+    it('keeps statements whose product PURL exactly matches an SBOM component', () => {
+      // SBOM has lodash@4.17.20; VEX has lodash@4.17.20 (CVE-2021-23337) and lodash@4.17.15 (CVE-2020-8203)
+      extractPurlsFromCdxBomMock.mockReturnValue(['pkg:npm/lodash@4.17.20']);
+
+      const result = filterByComponents(mockVex, mockSbom);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2021-23337');
+      expect(names).not.toContain('CVE-2020-8203');
+      expect(names).not.toContain('CVE-2018-20676');
+      expect(names).not.toContain('CVE-2022-31129');
+    });
+
+    it('requires exact version match — different versions do not match', () => {
+      // SBOM has lodash@4.17.21 but VEX only has lodash@4.17.20 and lodash@4.17.15
+      extractPurlsFromCdxBomMock.mockReturnValue(['pkg:npm/lodash@4.17.21']);
+
+      const result = filterByComponents(mockVex, mockSbom);
+
+      expect(result.statements).toHaveLength(0);
+    });
+
+    it('matches when PURL version is identical', () => {
+      extractPurlsFromCdxBomMock.mockReturnValue(['pkg:npm/lodash@4.17.20']);
+
+      const result = filterByComponents(mockVex, mockSbom);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2021-23337');
+    });
+
+    it('returns original VEX unchanged when SBOM has no PURLs', () => {
+      extractPurlsFromCdxBomMock.mockReturnValue([]);
+
+      const result = filterByComponents(mockVex, mockSbom);
+
+      expect(result).toBe(mockVex);
+    });
+
+    it('preserves non-statement fields on the document', () => {
+      extractPurlsFromCdxBomMock.mockReturnValue(['pkg:npm/lodash@4.17.20']);
+
+      const result = filterByComponents(mockVex, mockSbom);
+
+      expect(result['@context']).toBe(mockVex['@context']);
+      expect(result['@id']).toBe(mockVex['@id']);
+      expect(result.author).toBe(mockVex.author);
+    });
+  });
+
+  describe('filterByPackagePatterns', () => {
+    it('keeps statements with products matching any glob pattern', () => {
+      const result = filterByPackagePatterns(mockVex, ['pkg:npm/lodash*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2021-23337');
+      expect(names).toContain('CVE-2020-8203');
+      expect(names).not.toContain('CVE-2018-20676');
+      expect(names).not.toContain('CVE-2022-31129');
+    });
+
+    it('supports multiple patterns (OR logic)', () => {
+      const result = filterByPackagePatterns(mockVex, ['pkg:npm/lodash*', 'pkg:npm/moment*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2021-23337');
+      expect(names).toContain('CVE-2020-8203');
+      expect(names).toContain('CVE-2022-31129');
+      expect(names).not.toContain('CVE-2018-20676');
+    });
+
+    it('matching is case-insensitive', () => {
+      const result = filterByPackagePatterns(mockVex, ['pkg:NPM/LODASH*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2021-23337');
+    });
+
+    it('returns original VEX unchanged when patterns list is empty', () => {
+      const result = filterByPackagePatterns(mockVex, []);
+
+      expect(result).toBe(mockVex);
+    });
+
+    it('returns empty statements when no products match', () => {
+      const result = filterByPackagePatterns(mockVex, ['pkg:npm/nonexistent*']);
+
+      expect(result.statements).toHaveLength(0);
+    });
+  });
+
+  describe('filterByVulnPatterns', () => {
+    it('keeps statements whose vulnerability name matches a glob pattern', () => {
+      const result = filterByVulnPatterns(mockVex, ['CVE-2021-*']);
+
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0].vulnerability.name).toBe('CVE-2021-23337');
+    });
+
+    it('supports wildcard prefix matching', () => {
+      const result = filterByVulnPatterns(mockVex, ['CVE-202?-*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2021-23337');
+      expect(names).toContain('CVE-2022-31129');
+      expect(names).toContain('CVE-2020-8203');
+      expect(names).not.toContain('CVE-2018-20676');
+    });
+
+    it('supports multiple patterns (OR logic)', () => {
+      const result = filterByVulnPatterns(mockVex, ['CVE-2021-*', 'CVE-2022-*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2021-23337');
+      expect(names).toContain('CVE-2022-31129');
+      expect(names).not.toContain('CVE-2018-20676');
+    });
+
+    it('matching is case-insensitive', () => {
+      const result = filterByVulnPatterns(mockVex, ['cve-2021-*']);
+
+      expect(result.statements).toHaveLength(1);
+    });
+
+    it('returns original VEX unchanged when patterns list is empty', () => {
+      const result = filterByVulnPatterns(mockVex, []);
+
+      expect(result).toBe(mockVex);
+    });
+  });
+
+  describe('filterByStatus', () => {
+    it('keeps only statements with the given status', () => {
+      const result = filterByStatus(mockVex, ['not_affected']);
+
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0].status).toBe('not_affected');
+    });
+
+    it('supports filtering by multiple statuses', () => {
+      const result = filterByStatus(mockVex, ['not_affected', 'fixed']);
+
+      expect(result.statements).toHaveLength(2);
+      expect(result.statements.every((s) => s.status === 'not_affected' || s.status === 'fixed')).toBe(true);
+    });
+
+    it('returns empty statements when no match', () => {
+      const result = filterByStatus(mockVex, ['affected']);
+
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0].vulnerability.name).toBe('CVE-2021-23337');
+    });
+
+    it('returns original VEX unchanged when statuses list is empty', () => {
+      const result = filterByStatus(mockVex, []);
+
+      expect(result).toBe(mockVex);
+    });
+  });
+
+  describe('applyVexFilters', () => {
+    it('returns original VEX unchanged when no filters are provided', () => {
+      const result = applyVexFilters(mockVex, {});
+
+      expect(result).toBe(mockVex);
+    });
+
+    it('applies sbom filter when provided', () => {
+      extractPurlsFromCdxBomMock.mockReturnValue(['pkg:npm/lodash@4.17.20']);
+
+      const result = applyVexFilters(mockVex, { sbom: mockSbom });
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).not.toContain('CVE-2018-20676');
+      expect(names).toContain('CVE-2021-23337');
+    });
+
+    it('applies package pattern filter when provided', () => {
+      const result = applyVexFilters(mockVex, { packagePatterns: ['pkg:npm/moment*'] });
+
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0].vulnerability.name).toBe('CVE-2022-31129');
+    });
+
+    it('applies vuln pattern filter when provided', () => {
+      const result = applyVexFilters(mockVex, { vulnPatterns: ['CVE-2022-*'] });
+
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0].vulnerability.name).toBe('CVE-2022-31129');
+    });
+
+    it('applies status filter when provided', () => {
+      const result = applyVexFilters(mockVex, { statuses: ['fixed'] });
+
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0].status).toBe('fixed');
+    });
+
+    it('applies multiple filters sequentially (AND logic)', () => {
+      // Exact versions matching VEX products: lodash@4.17.20 (affected) + moment@2.29.3 (fixed)
+      extractPurlsFromCdxBomMock.mockReturnValue(['pkg:npm/lodash@4.17.20', 'pkg:npm/moment@2.29.3']);
+
+      // SBOM filter keeps lodash + moment statements; status filter keeps only 'affected'
+      const result = applyVexFilters(mockVex, {
+        sbom: mockSbom,
+        statuses: ['affected'],
+      });
+
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0].vulnerability.name).toBe('CVE-2021-23337');
+    });
+  });
+});

--- a/test/service/vex.svc.test.ts
+++ b/test/service/vex.svc.test.ts
@@ -15,6 +15,7 @@ import type { CdxBom } from '@herodevs/eol-shared';
 import { config } from '../../src/config/constants.ts';
 import {
   applyVexFilters,
+  excludeByPackagePatterns,
   fetchVexStatement,
   filterByComponents,
   filterByPackagePatterns,
@@ -271,6 +272,62 @@ describe('vex.svc', () => {
     });
   });
 
+  describe('excludeByPackagePatterns', () => {
+    it('removes statements whose products match the exclude pattern', () => {
+      const result = excludeByPackagePatterns(mockVex, ['pkg:npm/lodash*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).not.toContain('CVE-2021-23337');
+      expect(names).not.toContain('CVE-2020-8203');
+    });
+
+    it('keeps statements whose products do not match', () => {
+      const result = excludeByPackagePatterns(mockVex, ['pkg:npm/lodash*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2018-20676');
+      expect(names).toContain('CVE-2022-31129');
+    });
+
+    it('supports multiple patterns (OR logic — excludes if any pattern matches)', () => {
+      const result = excludeByPackagePatterns(mockVex, ['pkg:npm/lodash*', 'pkg:npm/moment*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).toContain('CVE-2018-20676');
+      expect(names).not.toContain('CVE-2021-23337');
+      expect(names).not.toContain('CVE-2022-31129');
+      expect(names).not.toContain('CVE-2020-8203');
+    });
+
+    it('matching is case-insensitive', () => {
+      const result = excludeByPackagePatterns(mockVex, ['pkg:NPM/LODASH*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).not.toContain('CVE-2021-23337');
+      expect(names).not.toContain('CVE-2020-8203');
+    });
+
+    it('returns original VEX unchanged when patterns list is empty', () => {
+      const result = excludeByPackagePatterns(mockVex, []);
+
+      expect(result).toBe(mockVex);
+    });
+
+    it('returns empty statements when all products match exclude pattern', () => {
+      const result = excludeByPackagePatterns(mockVex, ['pkg:npm/*']);
+
+      expect(result.statements).toHaveLength(0);
+    });
+
+    it('preserves non-statement fields on the document', () => {
+      const result = excludeByPackagePatterns(mockVex, ['pkg:npm/lodash*']);
+
+      expect(result['@context']).toBe(mockVex['@context']);
+      expect(result['@id']).toBe(mockVex['@id']);
+      expect(result.author).toBe(mockVex.author);
+    });
+  });
+
   describe('applyVexFilters', () => {
     it('returns original VEX unchanged when no filters are provided', () => {
       const result = applyVexFilters(mockVex, {});
@@ -321,6 +378,27 @@ describe('vex.svc', () => {
 
       expect(result.statements).toHaveLength(1);
       expect(result.statements[0].vulnerability.name).toBe('CVE-2021-23337');
+    });
+
+    it('applies excludePackagePatterns filter when provided', () => {
+      const result = applyVexFilters(mockVex, { excludePackagePatterns: ['pkg:npm/lodash*'] });
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).not.toContain('CVE-2021-23337');
+      expect(names).not.toContain('CVE-2020-8203');
+      expect(names).toContain('CVE-2018-20676');
+      expect(names).toContain('CVE-2022-31129');
+    });
+
+    it('applies excludePackagePatterns after include filters (AND logic)', () => {
+      // packagePatterns keeps only lodash statements; excludePackagePatterns then removes all of them
+      const result = applyVexFilters(mockVex, {
+        packagePatterns: ['pkg:npm/lodash*'],
+        excludePackagePatterns: ['pkg:npm/lodash@4.17.20'],
+      });
+
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0].vulnerability.name).toBe('CVE-2020-8203');
     });
   });
 });

--- a/test/service/vex.svc.test.ts
+++ b/test/service/vex.svc.test.ts
@@ -52,6 +52,15 @@ const mockVex: OpenVexDocument = {
       products: [{ '@id': 'pkg:npm/lodash@4.17.15' }],
       status: 'under_investigation',
     },
+    {
+      vulnerability: { name: 'CVE-2099-MULTI' },
+      products: [
+        { '@id': 'pkg:npm/react@17.0.0' },
+        { '@id': 'pkg:npm/react@18.0.0' },
+        { '@id': 'pkg:npm/react@19.0.0' },
+      ],
+      status: 'not_affected',
+    },
   ],
 };
 
@@ -160,6 +169,17 @@ describe('vex.svc', () => {
       expect(result['@id']).toBe(mockVex['@id']);
       expect(result.author).toBe(mockVex.author);
     });
+
+    it('narrows products to only those present in the SBOM, keeps statement', () => {
+      extractPurlsFromCdxBomMock.mockReturnValue(['pkg:npm/react@17.0.0']);
+
+      const result = filterByComponents(mockVex, mockSbom);
+
+      const multi = result.statements.find((s) => s.vulnerability.name === 'CVE-2099-MULTI');
+      expect(multi).toBeDefined();
+      expect(multi!.products).toHaveLength(1);
+      expect(multi!.products[0]['@id']).toBe('pkg:npm/react@17.0.0');
+    });
   });
 
   describe('filterByPackagePatterns', () => {
@@ -200,6 +220,22 @@ describe('vex.svc', () => {
       const result = filterByPackagePatterns(mockVex, ['pkg:npm/nonexistent*']);
 
       expect(result.statements).toHaveLength(0);
+    });
+
+    it('narrows products array to only matching products, keeps statement', () => {
+      const result = filterByPackagePatterns(mockVex, ['pkg:npm/react@17*']);
+
+      const multi = result.statements.find((s) => s.vulnerability.name === 'CVE-2099-MULTI');
+      expect(multi).toBeDefined();
+      expect(multi!.products).toHaveLength(1);
+      expect(multi!.products[0]['@id']).toBe('pkg:npm/react@17.0.0');
+    });
+
+    it('removes statement when no products match the pattern', () => {
+      const result = filterByPackagePatterns(mockVex, ['pkg:npm/vue*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).not.toContain('CVE-2099-MULTI');
     });
   });
 
@@ -247,14 +283,14 @@ describe('vex.svc', () => {
     it('keeps only statements with the given status', () => {
       const result = filterByStatus(mockVex, ['not_affected']);
 
-      expect(result.statements).toHaveLength(1);
-      expect(result.statements[0].status).toBe('not_affected');
+      expect(result.statements).toHaveLength(2);
+      expect(result.statements.every((s) => s.status === 'not_affected')).toBe(true);
     });
 
     it('supports filtering by multiple statuses', () => {
       const result = filterByStatus(mockVex, ['not_affected', 'fixed']);
 
-      expect(result.statements).toHaveLength(2);
+      expect(result.statements).toHaveLength(3);
       expect(result.statements.every((s) => s.status === 'not_affected' || s.status === 'fixed')).toBe(true);
     });
 
@@ -325,6 +361,25 @@ describe('vex.svc', () => {
       expect(result['@context']).toBe(mockVex['@context']);
       expect(result['@id']).toBe(mockVex['@id']);
       expect(result.author).toBe(mockVex.author);
+    });
+
+    it('removes only matching products, keeps statement when some products remain', () => {
+      const result = excludeByPackagePatterns(mockVex, ['pkg:npm/react@17*']);
+
+      const multi = result.statements.find((s) => s.vulnerability.name === 'CVE-2099-MULTI');
+      expect(multi).toBeDefined();
+      expect(multi!.products).toHaveLength(2);
+      expect(multi!.products.map((p) => p['@id'])).toEqual([
+        'pkg:npm/react@18.0.0',
+        'pkg:npm/react@19.0.0',
+      ]);
+    });
+
+    it('removes statement when all products are excluded', () => {
+      const result = excludeByPackagePatterns(mockVex, ['pkg:npm/react*']);
+
+      const names = result.statements.map((s) => s.vulnerability.name);
+      expect(names).not.toContain('CVE-2099-MULTI');
     });
   });
 

--- a/test/service/vex.svc.test.ts
+++ b/test/service/vex.svc.test.ts
@@ -99,9 +99,7 @@ describe('vex.svc', () => {
         statusText: 'Service Unavailable',
       } as unknown as Response);
 
-      await expect(fetchVexStatement()).rejects.toThrow(
-        'Failed to fetch VEX statement: HTTP 503 Service Unavailable',
-      );
+      await expect(fetchVexStatement()).rejects.toThrow('Failed to fetch VEX statement: HTTP 503 Service Unavailable');
     });
 
     it('fetches from the configured VEX statements URL', async () => {
@@ -177,8 +175,8 @@ describe('vex.svc', () => {
 
       const multi = result.statements.find((s) => s.vulnerability.name === 'CVE-2099-MULTI');
       expect(multi).toBeDefined();
-      expect(multi!.products).toHaveLength(1);
-      expect(multi!.products[0]['@id']).toBe('pkg:npm/react@17.0.0');
+      expect(multi?.products).toHaveLength(1);
+      expect(multi?.products[0]['@id']).toBe('pkg:npm/react@17.0.0');
     });
   });
 
@@ -227,8 +225,8 @@ describe('vex.svc', () => {
 
       const multi = result.statements.find((s) => s.vulnerability.name === 'CVE-2099-MULTI');
       expect(multi).toBeDefined();
-      expect(multi!.products).toHaveLength(1);
-      expect(multi!.products[0]['@id']).toBe('pkg:npm/react@17.0.0');
+      expect(multi?.products).toHaveLength(1);
+      expect(multi?.products[0]['@id']).toBe('pkg:npm/react@17.0.0');
     });
 
     it('removes statement when no products match the pattern', () => {
@@ -368,11 +366,8 @@ describe('vex.svc', () => {
 
       const multi = result.statements.find((s) => s.vulnerability.name === 'CVE-2099-MULTI');
       expect(multi).toBeDefined();
-      expect(multi!.products).toHaveLength(2);
-      expect(multi!.products.map((p) => p['@id'])).toEqual([
-        'pkg:npm/react@18.0.0',
-        'pkg:npm/react@19.0.0',
-      ]);
+      expect(multi?.products).toHaveLength(2);
+      expect(multi?.products.map((p) => p['@id'])).toEqual(['pkg:npm/react@18.0.0', 'pkg:npm/react@19.0.0']);
     });
 
     it('removes statement when all products are excluded', () => {


### PR DESCRIPTION
Add a VEX command, that allows for pulling of the HeroDevs VEX statement.

The command also provides a number of filtering flags, to whittle down the VEX statement to desired values. Flags are provided to filter by package name, CVE identifier, status, etc. There is also the ability to provide an input SBOM as a base for the filtering, to have VEX statement with results that apply to the given SBOM.