### PR TITLE
chore(auth): migrate keycloak base URL to auth herodevs

### DIFF
--- a/src/service/auth-config.svc.ts
+++ b/src/service/auth-config.svc.ts
@@ -1,8 +1,14 @@
-const DEFAULT_REALM_URL = 'https://idp.prod.apps.herodevs.io/realms/universe/protocol/openid-connect';
+const DEFAULT_KC_BASE = 'https://auth.herodevs.com/idp';
+const DEFAULT_KC_REALM = 'universe';
 const DEFAULT_CLIENT_ID = 'eol-ds';
 
 export function getRealmUrl() {
-  return process.env.OAUTH_CONNECT_URL || DEFAULT_REALM_URL;
+  if (process.env.OAUTH_CONNECT_URL) {
+    return process.env.OAUTH_CONNECT_URL;
+  }
+  const base = process.env.NES_KC_BASE || DEFAULT_KC_BASE;
+  const realm = process.env.NES_KC_REALM || DEFAULT_KC_REALM;
+  return `${base}/realms/${realm}/protocol/openid-connect`;
 }
 
 export function getClientId() {


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `idp.prod.apps.herodevs.io` default in
  `auth-config.svc.ts` with `auth.herodevs.com/idp`
- Adopts the org-recommended `NES_KC_BASE` / `NES_KC_REALM` env var.
- Preserves `OAUTH_CONNECT_URL` as a full-URL override for backwards
  compatibility.

**Priority order in `getRealmUrl()`:**
1. `OAUTH_CONNECT_URL` (full URL, existing override)
2. `NES_KC_BASE` + `NES_KC_REALM` (org Actions variables)
3. Hardcoded defaults (`https://auth.herodevs.com/idp` + `universe`)

## Test plan

- [ ] `hd auth login` completes successfully against prod (confirms
  `auth.herodevs.com/idp` OIDC endpoints are reachable)
- [ ] Setting `OAUTH_CONNECT_URL` still overrides the URL (backwards
  compat)
- [ ] Setting `NES_KC_BASE` + `NES_KC_REALM` constructs the expected
  realm URL