### PR TITLE
chore: replaces idp realm url

### DIFF
--- a/src/service/auth-config.svc.ts
+++ b/src/service/auth-config.svc.ts
@@ -1,14 +1,8 @@
-const DEFAULT_KC_BASE = 'https://auth.herodevs.com/idp';
-const DEFAULT_KC_REALM = 'universe';
+const DEFAULT_REALM_URL = 'https://auth.herodevs.com/idp/realms/universe/protocol/openid-connect';
 const DEFAULT_CLIENT_ID = 'eol-ds';
 
 export function getRealmUrl() {
-  if (process.env.OAUTH_CONNECT_URL) {
-    return process.env.OAUTH_CONNECT_URL;
-  }
-  const base = process.env.NES_KC_BASE || DEFAULT_KC_BASE;
-  const realm = process.env.NES_KC_REALM || DEFAULT_KC_REALM;
-  return `${base}/realms/${realm}/protocol/openid-connect`;
+  return process.env.OAUTH_CONNECT_URL || DEFAULT_REALM_URL;
 }
 
 export function getClientId() {


### PR DESCRIPTION
## Summary

- Simplifies `getRealmUrl()` in `src/service/auth-config.svc.ts` by replacing the separate `NES_KC_BASE` and `NES_KC_REALM` env var overrides with a single hardcoded default URL
- Removes `NES_KC_BASE` and `NES_KC_REALM` env var support — the full realm URL is now a single constant (`DEFAULT_REALM_URL`) rather than being assembled from parts
- `OAUTH_CONNECT_URL` override is preserved for cases that need a non-default endpoint

## Test plan

- [ ] Authenticate normally (no env overrides) — confirm it hits `https://auth.herodevs.com/idp/realms/universe/protocol/openid-connect`
- [ ] Set `OAUTH_CONNECT_URL` to a custom URL — confirm that value is used instead
- [ ] Confirm `NES_KC_BASE` / `NES_KC_REALM` are no longer referenced anywhere in the codebase
