### PR TITLE
feat(scan): include per-component remediations in saved JSON report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@amplitude/analytics-node": "^1.5.54",
         "@apollo/client": "^4.1.9",
         "@cyclonedx/cdxgen": "^12.2.0",
-        "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.19",
+        "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.20",
         "@inquirer/prompts": "^8.0.2",
         "@oclif/core": "^4.10.5",
         "@oclif/plugin-help": "^6.2.32",
@@ -2339,7 +2339,7 @@
     },
     "node_modules/@herodevs/eol-shared": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/herodevs/eol-shared.git#bb572272344d3ee53d5c7c30b9c619442051daa2",
+      "resolved": "git+ssh://git@github.com/herodevs/eol-shared.git#9e1ada64643ff801113d9361f14a49fabd067cdc",
       "license": "ISC",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "^9.4.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@amplitude/analytics-node": "^1.5.54",
     "@apollo/client": "^4.1.9",
     "@cyclonedx/cdxgen": "^12.2.0",
-    "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.19",
+    "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.20",
     "@inquirer/prompts": "^8.0.2",
     "@oclif/core": "^4.10.5",
     "@oclif/plugin-help": "^6.2.32",

--- a/src/api/gql-operations.ts
+++ b/src/api/gql-operations.ts
@@ -30,6 +30,7 @@ query GetEolReport($input: GetEolReportInput) {
             }
           }
         }
+        remediations
       }
       page
       totalRecords

--- a/test/service/file.svc.test.ts
+++ b/test/service/file.svc.test.ts
@@ -225,6 +225,33 @@ describe('file.svc', () => {
       expect(outputPath.includes(tempDir)).toBe(true);
     });
 
+    it('should preserve per-component remediations in the saved report', async () => {
+      tempDir = createTempDir();
+
+      const reportWithRemediations: EolReport = {
+        ...mockReport,
+        components: [
+          {
+            purl: 'pkg:npm/bootstrap@3.1.1',
+            metadata: null,
+            remediations: [
+              {
+                type: 'nes_available',
+                description: 'Secured, supported, drop-in replacement',
+                action: { type: 'direct', url: 'https://www.herodevs.com/support/bootstrap-nes' },
+                target: { purl: 'pkg:npm/bootstrap@3.1.1', version: '3.1.1' },
+              },
+            ],
+          },
+        ],
+      };
+
+      const outputPath = saveArtifactToFile(tempDir, { kind: 'report', payload: reportWithRemediations });
+
+      const parsed = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+      expect(parsed.components[0].remediations).toEqual(reportWithRemediations.components[0].remediations);
+    });
+
     it('should save report to a custom path', async () => {
       tempDir = createTempDir();
       const customDir = join(tempDir, 'nested');


### PR DESCRIPTION
## What This Branch Does

Adds the per-component `remediations` array to the saved JSON scan report. The CLI now requests `remediations` from the EOL report query and persists it on each component, and bumps `@herodevs/eol-shared` to `v0.1.20` for the `Remediation` type. Displayed scan output is unchanged.

## Report JSON: Per-Component Remediations

- Selects the new field in the report query: [`gql-operations.ts` R33](https://github.com/herodevs/cli/pull/581/files#diff-bb92f66bd245ac6e3825b2f25f5a50681f1156f8ab8f7d9ddece2134d4c4093dR33) — `remediations` is added to the `components` selection in `GetEolReport`, as a sibling of `nesRemediation`. eol-api serves it as a `JSON` scalar, so it is selected as a leaf.
- Bumps the shared types package: [`package.json` R48](https://github.com/herodevs/cli/pull/581/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48) — `@herodevs/eol-shared` to `#v0.1.20`, which introduces the `Remediation` type and the optional `remediations` field on `EolScanComponent`.
- The saved report is the raw `EolReport`, so the new field flows into the JSON without transformation. The display path (`display.svc.ts`) is untouched, satisfying "no updates to displayed scan output".

## Test Coverage

- [`file.svc.test.ts` R228](https://github.com/herodevs/cli/pull/581/files#diff-5601a8a0719e4cb0ba5cfcfb3ac790d47be70dfbe90915fbde55dd3387d83e61R228) — new test asserting that per-component `remediations` survive the save → read round-trip in `herodevs.report.json`.

## Known Gaps / Deploy Coordination

- **Do not ship until the eol-api prod schema exposes `EolComponentScanResult.remediations`** — otherwise the GraphQL query selecting `remediations` fails validation and breaks the scan. Depends on the eol-engine prod cutover + API deploy to prod.
