### PR TITLE
chore: updates apollo-client and graphql to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-node": "^1.5.59",
-        "@apollo/client": "^4.1.9",
+        "@apollo/client": "^4.2.3",
         "@cyclonedx/cdxgen": "^12.5.1",
         "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.20",
         "@inquirer/prompts": "^8.0.2",
@@ -22,7 +22,7 @@
         "conf": "^15.1.0",
         "date-fns": "^4.4.0",
         "glob": "^13.0.0",
-        "graphql": "^16.13.2",
+        "graphql": "^17.0.0",
         "node-machine-id": "^1.1.12",
         "ora": "^9.4.0",
         "packageurl-js": "^2.0.1",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.1.9.tgz",
-      "integrity": "sha512-qfpkQD51tdU/7iAR6aLb4w9o/L7I475DluWHRb61U/3Q0AH29nNOxOBHjBbWDdf16ncPOoQuxne1sEs2NjqBFw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.3.tgz",
+      "integrity": "sha512-+auRYBXow2v7cT+wKzvjyMyyEojq+G7Sf80vIR57rtEPcxRFuMXuU9IKjwxZ3muclUgdGKwZXNeuki+g0GabgQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -135,7 +135,7 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^16.0.0",
+        "graphql": "^16.0.0 || ^17.0.0",
         "graphql-ws": "^5.5.5 || ^6.0.3",
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
         "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
@@ -6857,12 +6857,12 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.0.tgz",
+      "integrity": "sha512-RSEgqrRNqHVGa46w2pmL9uTFkYPJiJbD5kksOvOaPLrKvBIidX/ttQVlWsR3+Ee8l+mNroC6darpcPIZeElbNg==",
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+        "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
       }
     },
     "node_modules/graphql-tag": {
@@ -10384,6 +10384,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@amplitude/analytics-node": "^1.5.59",
-    "@apollo/client": "^4.1.9",
+    "@apollo/client": "^4.2.3",
     "@cyclonedx/cdxgen": "^12.5.1",
     "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.20",
     "@inquirer/prompts": "^8.0.2",
@@ -55,7 +55,7 @@
     "conf": "^15.1.0",
     "date-fns": "^4.4.0",
     "glob": "^13.0.0",
-    "graphql": "^16.13.2",
+    "graphql": "^17.0.0",
     "node-machine-id": "^1.1.12",
     "ora": "^9.4.0",
     "packageurl-js": "^2.0.1",

--- a/src/api/apollo.client.ts
+++ b/src/api/apollo.client.ts
@@ -2,6 +2,22 @@ import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client/core';
 import { requireAccessTokenForScan } from '../service/auth.svc.ts';
 import { ApiError, PAYLOAD_TOO_LARGE_ERROR_CODE } from './errors.ts';
 
+declare module '@apollo/client/core' {
+  interface TypeOverrides {
+    signatureStyle: 'classic';
+  }
+  namespace ApolloClient {
+    namespace DeclareDefaultOptions {
+      interface Query {
+        errorPolicy: 'all';
+      }
+      interface Mutate {
+        errorPolicy: 'all';
+      }
+    }
+  }
+}
+
 export type TokenProvider = (forceRefresh?: boolean) => Promise<string>;
 
 function isTokenEndpoint(input: string | URL | Request): boolean {


### PR DESCRIPTION
### Summary

- Bumps `@apollo/client` from `^4.1.9` → `^4.2.3`
- Bumps `graphql` from `^16.13.2` → `^17.0.0` (Apollo 4.2.x declares support for both `^16` and `^17`)
- Adds module augmentations to `apollo.client.ts` to satisfy Apollo 4.2.x's new type-safety requirements

---

### Why the type augmentations are needed

Apollo Client 4.2 introduced two breaking type-system changes:

#### 1. `DeclareDefaultOptions` — required before using `errorPolicy` as a default

Apollo 4.2 uses a type-guard pattern that makes `errorPolicy` in `defaultOptions` resolve to an error-message string type unless explicitly declared via module augmentation. Without this, the `createApollo` factory produced a `TS2322` error.

#### 2. `SignatureStyle` — modern vs. classic call signatures

Declaring non-empty `DeclareDefaultOptions` interfaces causes Apollo to automatically switch `client.mutate` and `client.query` to the new **"modern"** signature style, which:
- Requires `TypedDocumentNode` and type inference
- Does **not** accept explicit `<TData, TVariables>` type arguments

Since all existing call sites use explicit generics against plain `DocumentNode`, we pin `signatureStyle: 'classic'` in `TypeOverrides` to preserve backward-compatible behavior.

> **Future work:** migrating to the modern signature style involves typing each `gql` document as `TypedDocumentNode<ResponseType, VariablesType>` and removing explicit generic arguments from all `client.mutate`/`client.query` call sites. The five documents in `gql-operations.ts` are the starting point.

---

### Test plan

- [ ] `npm run typecheck` passes with zero errors
- [ ] `npm test` passes
- [ ] Manual smoke test: `hd scan` completes successfully
