### PR TITLE
fix(scan): count packages with unknownReason metadata as UNKNOWN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@amplitude/analytics-node": "^1.5.59",
         "@apollo/client": "^4.2.3",
         "@cyclonedx/cdxgen": "^12.5.1",
-        "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.20",
+        "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.23",
         "@inquirer/prompts": "^8.0.2",
         "@oclif/core": "^4.11.4",
         "@oclif/plugin-help": "^6.2.32",
@@ -1774,13 +1774,13 @@
     },
     "node_modules/@herodevs/eol-shared": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/herodevs/eol-shared.git#9e1ada64643ff801113d9361f14a49fabd067cdc",
+      "resolved": "git+ssh://git@github.com/herodevs/eol-shared.git#1a326d22002568be6632b2c4667c6e6e3aaca20b",
       "license": "ISC",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "^9.4.1",
         "fast-xml-parser": "^5.3.3",
         "json-schema-to-typescript": "^15.0.4",
-        "packageurl-js": "^2.0.1"
+        "packageurl-js": "2.0.1"
       },
       "engines": {
         "node": ">=22"
@@ -10384,7 +10384,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@amplitude/analytics-node": "^1.5.59",
     "@apollo/client": "^4.2.3",
     "@cyclonedx/cdxgen": "^12.5.1",
-    "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.20",
+    "@herodevs/eol-shared": "github:herodevs/eol-shared#v0.1.23",
     "@inquirer/prompts": "^8.0.2",
     "@oclif/core": "^4.11.4",
     "@oclif/plugin-help": "^6.2.32",

--- a/test/service/display.svc.test.ts
+++ b/test/service/display.svc.test.ts
@@ -39,7 +39,7 @@ describe('display.svc', () => {
       },
       {
         purl: 'pkg:npm/test3@3.0.0',
-        metadata: null,
+        metadata: { unknownReason: 'not_identifiable' },
       },
       {
         purl: 'pkg:npm/%40scoped/package@1.0.0',
@@ -79,6 +79,29 @@ describe('display.svc', () => {
       expect(counts.UNKNOWN).toBe(1);
       expect(counts.EOL_UPCOMING).toBe(0);
       expect(counts.NES_AVAILABLE).toBe(1);
+    });
+
+    it('should count components with only an unknownReason as UNKNOWN, not OK', () => {
+      const unknownReports: EolReport = {
+        ...mockReport,
+        components: [
+          {
+            purl: 'pkg:npm/mystery@1.0.0',
+            metadata: { unknownReason: 'not_identifiable' },
+          },
+          {
+            purl: 'pkg:npm/queued@2.0.0',
+            metadata: { unknownReason: 'queued' },
+          },
+        ],
+      };
+
+      const counts = countComponentsByStatus(unknownReports);
+
+      expect(counts.UNKNOWN).toBe(2);
+      expect(counts.OK).toBe(0);
+      expect(counts.EOL).toBe(0);
+      expect(counts.EOL_UPCOMING).toBe(0);
     });
 
     it('should extract ecosystems correctly from various PURL formats', () => {

--- a/test/service/file.svc.test.ts
+++ b/test/service/file.svc.test.ts
@@ -233,7 +233,7 @@ describe('file.svc', () => {
         components: [
           {
             purl: 'pkg:npm/bootstrap@3.1.1',
-            metadata: null,
+            metadata: { unknownReason: 'not_identifiable' },
             remediations: [
               {
                 type: 'nes_available',


### PR DESCRIPTION
## Summary

- Restore correct EOL scan counts after the eol-api changed the component `metadata` shape: unknown/unresolvable packages now arrive as `{ unknownReason }` instead of `null`.
- Without this, every unknown package was silently counted as "Not End-of-Life (EOL)" in scan output and in the `eol_unknown_count` analytics metric.

## Changes

- Bump `@herodevs/eol-shared` from `v0.1.20` to `v0.1.23`, which teaches `deriveComponentStatus` to treat `{ unknownReason }` metadata as `UNKNOWN` and models the `ComponentMetadata` union (`EolScanComponentMetadata | UnknownComponentMetadata`).
- Update `package-lock.json` to the resolved `v0.1.23` commit.
- Migrate test fixtures off the removed `metadata: null` shape to `{ unknownReason }` in `display.svc.test.ts` and `file.svc.test.ts`.
- Add a regression test asserting components with only an `unknownReason` count as `UNKNOWN` and not `OK`.

## Testing

- `npm run typecheck` — passes
- `npm run lint` — passes
- `npm run test` — 248 passed (24 files)

## Screenshots

n/a

## Risks & Rollback

- Low risk. The behavioral fix lives entirely in the `@herodevs/eol-shared` bump; the sole CLI consumer (`countComponentsByStatus`) delegates to the library and is otherwise unchanged.
- The GraphQL selection is unaffected — `metadata` is an opaque JSON scalar, so no query changes.
- Rollback: revert the `@herodevs/eol-shared` pin to `v0.1.20` and the accompanying `package-lock.json` change.

## Checklist

- [x] Tests added or updated
- [x] Linting passes
- [x] Typecheck passes
- [x] No breaking changes without clear migration notes
- [ ] Environment variables documented (if added/changed) — n/a
